### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ This build plugin is a utility for enabling server-side rendering in Next.js on 
 
 ## Installation and Configuration
 
-1. `npm install netlify-plugin-nextjs`
-
-2. Create a `netlify.toml` in the root of your poject:
+Create a `netlify.toml` in the root of your project:
 
 ```toml
 [build]


### PR DESCRIPTION
Because of the way we're planning to serve this plugin (now and in the near future), the `npm install` step isn't necessary. Yay for simpler instructions!