### PR TITLE
Improve framework detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1218,9 +1218,9 @@
       }
     },
     "@netlify/framework-info": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-0.1.3.tgz",
-      "integrity": "sha512-+dIXlgXpbYTwUHniNQPWu78bnlqC98eYE+TmWRDoFmELAHGISqbE1viRdQTxixU4B27HSy7mDqEk/RSV/irfRg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@netlify/framework-info/-/framework-info-0.2.0.tgz",
+      "integrity": "sha512-q4G4+FODron6wSwwEDyDB2g80PFBwAQzV3AUZ825E2v+2ONaAe0JIfqnUAV62d7lhg42lf4WreTacbpKpuPeqg==",
       "requires": {
         "filter-obj": "^2.0.1",
         "is-plain-obj": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/netlify/netlify-plugin-nextjs#readme",
   "dependencies": {
-    "@netlify/framework-info": "^0.1.3",
+    "@netlify/framework-info": "^0.2.0",
     "cpx": "^1.5.0",
     "make-dir": "^3.1.0",
     "next-on-netlify": "^2.6.0"


### PR DESCRIPTION
This uses the new `hasFramework()` method from `@netlify/framework-info` to simplify the framework detection logic.

This PR also removes the framework detection inside `onPostBuild` since, if the project is not using Next.js, the build would have already failed due to the `failBuild()` in `onPreBuild`.

This PR does not fix line indentation in order to make the git diff clearer, but line indentation should probably be fixed after merge.