### PR TITLE
Use `packageJson`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const isStaticExportProject = require('./helpers/isStaticExportProject');
 // - Between the build and postbuild steps, any functions are bundled
 
 module.exports = {
-  async onPreBuild({ constants, netlifyConfig, utils }) {
+  async onPreBuild({ netlifyConfig, packageJson: { scripts = {}, dependencies = {} }, utils }) {
     if (!(await hasFramework('next'))) {
       return failBuild(`This application does not use Next.js.`);
     }
@@ -26,21 +26,6 @@ module.exports = {
       // TO-DO: Post alpha, try to remove this workaround for missing deps in
       // the next-on-netlify function template
       await utils.run.command('npm install next-on-netlify@latest');
-
-      // Require the project's package.json for access to its scripts
-      // and dependencies in order to check existing project configuration
-      let packageJson;
-      if (existsSync(path.resolve(constants.PUBLISH_DIR, 'package.json'))) {
-        packageJson = require(path.resolve(constants.PUBLISH_DIR, 'package.json'));
-      } else if (existsSync(path.resolve(constants.PUBLISH_DIR, '..', 'package.json'))) {
-        packageJson = require(path.resolve(constants.PUBLISH_DIR, '..', 'package.json'));
-      } else {
-        failBuild(`Cannot locate your package.json file. Please make sure your package.json is
-          at the root of your project or in your publish directory.`
-        );
-      }
-
-      const { scripts, dependencies } = packageJson;
 
       if (isStaticExportProject({ build, scripts })) {
         failBuild(`** Static HTML export next.js projects do not require this plugin **`);


### PR DESCRIPTION
This adds the new `packageJson` argument passed to plugin handlers, which helps simplifying code and handle any edge case (for example, the current code did not work when using a `base` directory with a `package.json` several directories above it).

Note: you will need to upgrade Netlify Build to `5.1.0` (the version is shown in build logs) to try this locally. Until we make a release of the CLI, in the repository which uses `netlify-cli`, this can be done by removing your `package-lock.json` and `node_modules`, then running `npm install` again. If installed globally, this can be done by re-installing `netlify-cli` globally.