### PR TITLE
Functions UI build settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ const isStaticExportProject = require('./helpers/isStaticExportProject')
 // - Between the build and postbuild steps, any functions are bundled
 
 module.exports = {
-  async onPreBuild({ netlifyConfig, packageJson, utils }) {
+  async onPreBuild({ netlifyConfig, packageJson, utils, constants: { FUNCTIONS_SRC } }) {
     const { failBuild } = utils.build
 
     if (!packageJson) {
@@ -46,7 +46,8 @@ module.exports = {
     //   failBuild(`This plugin cannot support apps that manually use next-on-netlify. Uninstall next-on-netlify as a dependency to resolve.`);
     // }
 
-    const isFunctionsDirectoryCorrect = build && build.functions && build.functions === path.resolve('out_functions')
+    const isFunctionsDirectoryCorrect =
+      FUNCTIONS_SRC !== undefined && path.resolve(FUNCTIONS_SRC) === path.resolve('out_functions')
     if (!isFunctionsDirectoryCorrect) {
       // to do rephrase
       failBuild(

--- a/test/index.js
+++ b/test/index.js
@@ -39,6 +39,7 @@ describe('preBuild()', () => {
       netlifyConfig: {},
       packageJson,
       utils,
+      constants: { FUNCTIONS_SRC: 'out_functions' },
     })
 
     expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
@@ -54,6 +55,7 @@ describe('preBuild()', () => {
       netlifyConfig,
       packageJson,
       utils,
+      constants: { FUNCTIONS_SRC: 'out_functions' },
     })
 
     expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
@@ -62,13 +64,13 @@ describe('preBuild()', () => {
   })
 
   test('fail build if the app has no functions directory defined', async () => {
-    const netlifyConfig = { build: {} }
     const packageJson = {}
 
     await plugin.onPreBuild({
-      netlifyConfig,
+      netlifyConfig: {},
       packageJson,
       utils,
+      constants: {},
     })
 
     expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
@@ -81,13 +83,13 @@ describe('preBuild()', () => {
       netlifyConfig: {},
       packageJson: {},
       utils,
+      constants: { FUNCTIONS_SRC: 'out_functions' },
     })
 
     expect(makef.createFile.mock.calls.length).toEqual(1)
   })
 
   test(`fail build if the app's next config has an invalid target`, async () => {
-    const netlifyConfig = { build: { functions: path.resolve('out_functions') } }
     mockFs({
       'next.config.js': {
         target: 'nonsense',
@@ -95,9 +97,10 @@ describe('preBuild()', () => {
     })
 
     await plugin.onPreBuild({
-      netlifyConfig,
+      netlifyConfig: {},
       packageJson: {},
       utils,
+      constants: { FUNCTIONS_SRC: 'out_functions' },
     })
 
     mockFs.restore()


### PR DESCRIPTION
Fixes #11.

The following line:

https://github.com/netlify/netlify-plugin-nextjs/blob/7b9a2430f46da57a38c5c85d611b2fc7df6bd777/index.js#L59

Is checking the `build.functions` configuration property in `netlify.toml`. However, [`constants.FUNCTIONS_SRC`](https://docs.netlify.com/configure-builds/build-plugins/create-plugins/#constants) should be used instead, since it takes more cases into account, such as when users are creating functions directory during build.