### PR TITLE
Fix `package.json` validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = {
   async onPreBuild({ netlifyConfig, packageJson, utils, constants: { FUNCTIONS_SRC } }) {
     const { failBuild } = utils.build
 
-    if (!packageJson) {
+    if (Object.keys(packageJson).length === 0) {
       failBuild(`Could not find a package.json for this project`)
       return
     }

--- a/test/index.js
+++ b/test/index.js
@@ -31,13 +31,13 @@ jest.mock('cpx')
 // for why this log is required
 console.log('Initializing tests')
 
+const DUMMY_PACKAGE_JSON = { name: 'dummy', version: '1.0.0' }
+
 describe('preBuild()', () => {
   test('fail build if the app has static html export in npm script', async () => {
-    const packageJson = { scripts: { build: 'next export' } }
-
     await plugin.onPreBuild({
       netlifyConfig: {},
-      packageJson,
+      packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { build: 'next export' } },
       utils,
       constants: { FUNCTIONS_SRC: 'out_functions' },
     })
@@ -49,11 +49,10 @@ describe('preBuild()', () => {
 
   test('fail build if the app has static html export in toml/ntl config', async () => {
     const netlifyConfig = { build: { command: 'next build && next export' } }
-    const packageJson = {}
 
     await plugin.onPreBuild({
       netlifyConfig,
-      packageJson,
+      packageJson: DUMMY_PACKAGE_JSON,
       utils,
       constants: { FUNCTIONS_SRC: 'out_functions' },
     })
@@ -63,12 +62,21 @@ describe('preBuild()', () => {
     )
   })
 
-  test('fail build if the app has no functions directory defined', async () => {
-    const packageJson = {}
-
+  test('fail build if the app has no package.json', async () => {
     await plugin.onPreBuild({
       netlifyConfig: {},
-      packageJson,
+      packageJson: {},
+      utils,
+      constants: { FUNCTIONS_SRC: 'out_functions' },
+    })
+
+    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(`Could not find a package.json for this project`)
+  })
+
+  test('fail build if the app has no functions directory defined', async () => {
+    await plugin.onPreBuild({
+      netlifyConfig: {},
+      packageJson: DUMMY_PACKAGE_JSON,
       utils,
       constants: {},
     })
@@ -81,7 +89,7 @@ describe('preBuild()', () => {
   test('create next.config.js with correct target if file does not exist', async () => {
     await plugin.onPreBuild({
       netlifyConfig: {},
-      packageJson: {},
+      packageJson: DUMMY_PACKAGE_JSON,
       utils,
       constants: { FUNCTIONS_SRC: 'out_functions' },
     })
@@ -98,7 +106,7 @@ describe('preBuild()', () => {
 
     await plugin.onPreBuild({
       netlifyConfig: {},
-      packageJson: {},
+      packageJson: DUMMY_PACKAGE_JSON,
       utils,
       constants: { FUNCTIONS_SRC: 'out_functions' },
     })


### PR DESCRIPTION
Fixes #22.

The line checks for `packageJson` being falsy:

https://github.com/netlify/netlify-plugin-nextjs/blob/2849dc5f7c57e9fd827a939e067a871e4cb487b1/index.js#L21

However, when a site has no `package.json`, `packageJson` is an empty object. Therefore, `Object.keys(packageJson).length === 0` should be used instead.

This PR also adds a test for it.