### PR TITLE
Run tests on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,11 +7,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node-version: [10.x, 14.x]
+        exclude:
+          - os: macOS-latest
+            node-version: 10.x
+          - os: windows-latest
+            node-version: 10.x
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #21.

We should run CI tests on Windows and macOS as well, to ensure this plugin works for Netlify CLI users who run `netlify build`.

Many of our CLI users are on Windows (example for [`next-on-netlify`](https://github.com/netlify/next-on-netlify/issues/56#issuecomment-709670418)).

This PR also runs Node only in Node 10 and 14 (not 12) to make CI tests faster. In my experience, it is very rare for something not to work in a specific Node.js release but not in both the previous and the next major release.