### PR TITLE
Remove `netlifyConfig` check

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,11 +23,6 @@ module.exports = {
       return
     }
 
-    if (!netlifyConfig) {
-      failBuild(`Could not find a Netlify configuration for this project`)
-      return
-    }
-
     const { build } = netlifyConfig
     const { scripts = {}, dependencies = {} } = packageJson
 


### PR DESCRIPTION
Fixes #23.

The following check:

https://github.com/netlify/netlify-plugin-nextjs/blob/2849dc5f7c57e9fd827a939e067a871e4cb487b1/index.js#L26

Can be removed since `netlifyConfig` is always defined.