### PR TITLE
Fix `next.config.js` resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const util = require('util')
 const nextOnNetlify = require('next-on-netlify')
 const { PHASE_PRODUCTION_BUILD } = require('next/constants')
 const { default: loadConfig } = require('next/dist/next-server/server/config')
+const findUp = require('find-up')
 const makeDir = require('make-dir')
 const pathExists = require('path-exists')
 const cpx = require('cpx')
@@ -52,8 +53,8 @@ module.exports = {
       )
     }
 
-    const hasNextConfig = await pathExists('next.config.js')
-    if (hasNextConfig) {
+    const nextConfigPath = await findUp('next.config.js')
+    if (nextConfigPath !== undefined) {
       // If the next config exists, fail build if target isnt in acceptableTargets
       const acceptableTargets = ['serverless', 'experimental-serverless-trace']
       const nextConfig = loadConfig(PHASE_PRODUCTION_BUILD, path.resolve('.'))

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://github.com/netlify/netlify-plugin-nextjs#readme",
   "dependencies": {
     "cpx": "^1.5.0",
+    "find-up": "^4.1.0",
     "make-dir": "^3.1.0",
     "next": "^9.5.3",
     "next-on-netlify": "^2.6.0",

--- a/test/fixtures/deep_invalid_next_config/next.config.js
+++ b/test/fixtures/deep_invalid_next_config/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  target: 'server',
+}

--- a/test/index.js
+++ b/test/index.js
@@ -117,17 +117,20 @@ describe('preBuild()', () => {
     expect(await pathExists('next.config.js')).toBeTruthy()
   })
 
-  test(`fail build if the app's next config has an invalid target`, async () => {
-    await useFixture('invalid_next_config')
-    await expect(
-      plugin.onPreBuild({
-        netlifyConfig: {},
-        packageJson: DUMMY_PACKAGE_JSON,
-        utils,
-        constants: { FUNCTIONS_SRC: 'out_functions' },
-      }),
-    ).rejects.toThrow(`next.config.js must be one of: serverless, experimental-serverless-trace`)
-  })
+  test.each(['invalid_next_config', 'deep_invalid_next_config'])(
+    `fail build if the app's next config has an invalid target`,
+    async (fixtureName) => {
+      await useFixture(fixtureName)
+      await expect(
+        plugin.onPreBuild({
+          netlifyConfig: {},
+          packageJson: DUMMY_PACKAGE_JSON,
+          utils,
+          constants: { FUNCTIONS_SRC: 'out_functions' },
+        }),
+      ).rejects.toThrow(`next.config.js must be one of: serverless, experimental-serverless-trace`)
+    },
+  )
 })
 
 describe('onBuild()', () => {


### PR DESCRIPTION
Fixes #24

In a monorepo setup, it is possible that `next.config.js` might be in a parent directory if the user has set a `base` directory.
Next.js is searching `next.config.js` in parent directories using [`find-up`](https://github.com/sindresorhus/find-up):

https://github.com/vercel/next.js/blob/497cac4b93de9ecf6c7ed79bd6557dcd3bb51be5/packages/next/next-server/server/config.ts#L450

However we are not currently searching it in parent directories:

https://github.com/netlify/netlify-plugin-nextjs/blob/2849dc5f7c57e9fd827a939e067a871e4cb487b1/index.js#L57

Using `find-up` should fix this bug.

This also adds a test for it.