### PR TITLE
Fix `failBuild()` testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,8 +22,7 @@ module.exports = {
     const { failBuild } = utils.build
 
     if (Object.keys(packageJson).length === 0) {
-      failBuild(`Could not find a package.json for this project`)
-      return
+      return failBuild(`Could not find a package.json for this project`)
     }
 
     const { build } = netlifyConfig
@@ -34,21 +33,21 @@ module.exports = {
     await utils.run.command('npm install next-on-netlify@latest')
 
     if (isStaticExportProject({ build, scripts })) {
-      failBuild(`** Static HTML export next.js projects do not require this plugin **`)
+      return failBuild(`** Static HTML export next.js projects do not require this plugin **`)
     }
 
     // TO-DO: check scripts to make sure the app isn't manually running NoN
     // For now, we'll make it clear in the README
     // const isAlreadyUsingNextOnNetlify = Object.keys(dependencies).find((dep) => dep === 'next-on-netlify');
     // if (isAlreadyUsingNextOnNetlify) {
-    //   failBuild(`This plugin cannot support apps that manually use next-on-netlify. Uninstall next-on-netlify as a dependency to resolve.`);
+    //   return failBuild(`This plugin cannot support apps that manually use next-on-netlify. Uninstall next-on-netlify as a dependency to resolve.`);
     // }
 
     const isFunctionsDirectoryCorrect =
       FUNCTIONS_SRC !== undefined && path.resolve(FUNCTIONS_SRC) === path.resolve('out_functions')
     if (!isFunctionsDirectoryCorrect) {
       // to do rephrase
-      failBuild(
+      return failBuild(
         `You must designate a functions directory named "out_functions" in your netlify.toml or in your app's build settings on Netlify. See docs for more info: https://docs.netlify.com/functions/configure-and-deploy/#configure-the-functions-folder`,
       )
     }
@@ -60,7 +59,7 @@ module.exports = {
       const nextConfig = loadConfig(PHASE_PRODUCTION_BUILD, path.resolve('.'))
       const isValidTarget = acceptableTargets.includes(nextConfig.target)
       if (!isValidTarget) {
-        failBuild(`next.config.js must be one of: ${acceptableTargets.join(', ')}`)
+        return failBuild(`next.config.js must be one of: ${acceptableTargets.join(', ')}`)
       }
     } else {
       // Create the next config file with target set to serverless by default

--- a/test/index.js
+++ b/test/index.js
@@ -11,10 +11,12 @@ const FIXTURES_DIR = `${__dirname}/fixtures`
 
 const utils = {
   run: {
-    command: jest.fn(),
+    command() {},
   },
   build: {
-    failBuild: jest.fn(),
+    failBuild(message) {
+      throw new Error(message)
+    },
   },
 }
 
@@ -41,8 +43,6 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
-  utils.build.failBuild.mockReset()
-  utils.run.command.mockReset()
   jest.clearAllMocks()
   jest.resetAllMocks()
 
@@ -58,53 +58,47 @@ const DUMMY_PACKAGE_JSON = { name: 'dummy', version: '1.0.0' }
 
 describe('preBuild()', () => {
   test('fail build if the app has static html export in npm script', async () => {
-    await plugin.onPreBuild({
-      netlifyConfig: {},
-      packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { build: 'next export' } },
-      utils,
-      constants: { FUNCTIONS_SRC: 'out_functions' },
-    })
-
-    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
-      '** Static HTML export next.js projects do not require this plugin **',
-    )
+    await expect(
+      plugin.onPreBuild({
+        netlifyConfig: {},
+        packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { build: 'next export' } },
+        utils,
+        constants: { FUNCTIONS_SRC: 'out_functions' },
+      }),
+    ).rejects.toThrow('** Static HTML export next.js projects do not require this plugin **')
   })
 
   test('fail build if the app has static html export in toml/ntl config', async () => {
-    const netlifyConfig = { build: { command: 'next build && next export' } }
-
-    await plugin.onPreBuild({
-      netlifyConfig,
-      packageJson: DUMMY_PACKAGE_JSON,
-      utils,
-      constants: { FUNCTIONS_SRC: 'out_functions' },
-    })
-
-    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
-      '** Static HTML export next.js projects do not require this plugin **',
-    )
+    await expect(
+      plugin.onPreBuild({
+        netlifyConfig: { build: { command: 'next build && next export' } },
+        packageJson: DUMMY_PACKAGE_JSON,
+        utils,
+        constants: { FUNCTIONS_SRC: 'out_functions' },
+      }),
+    ).rejects.toThrow('** Static HTML export next.js projects do not require this plugin **')
   })
 
   test('fail build if the app has no package.json', async () => {
-    await plugin.onPreBuild({
-      netlifyConfig: {},
-      packageJson: {},
-      utils,
-      constants: { FUNCTIONS_SRC: 'out_functions' },
-    })
-
-    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(`Could not find a package.json for this project`)
+    await expect(
+      plugin.onPreBuild({
+        netlifyConfig: {},
+        packageJson: {},
+        utils,
+        constants: { FUNCTIONS_SRC: 'out_functions' },
+      }),
+    ).rejects.toThrow(`Could not find a package.json for this project`)
   })
 
   test('fail build if the app has no functions directory defined', async () => {
-    await plugin.onPreBuild({
-      netlifyConfig: {},
-      packageJson: DUMMY_PACKAGE_JSON,
-      utils,
-      constants: {},
-    })
-
-    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
+    await expect(
+      plugin.onPreBuild({
+        netlifyConfig: {},
+        packageJson: DUMMY_PACKAGE_JSON,
+        utils,
+        constants: {},
+      }),
+    ).rejects.toThrow(
       `You must designate a functions directory named "out_functions" in your netlify.toml or in your app's build settings on Netlify. See docs for more info: https://docs.netlify.com/functions/configure-and-deploy/#configure-the-functions-folder`,
     )
   })
@@ -122,18 +116,15 @@ describe('preBuild()', () => {
 
   test(`fail build if the app's next config has an invalid target`, async () => {
     const { restoreCwd } = useFixture('invalid_next_config')
-    await plugin.onPreBuild({
-      netlifyConfig: {},
-      packageJson: DUMMY_PACKAGE_JSON,
-      utils,
-      constants: { FUNCTIONS_SRC: 'out_functions' },
-    })
+    await expect(
+      plugin.onPreBuild({
+        netlifyConfig: {},
+        packageJson: DUMMY_PACKAGE_JSON,
+        utils,
+        constants: { FUNCTIONS_SRC: 'out_functions' },
+      }),
+    ).rejects.toThrow(`next.config.js must be one of: serverless, experimental-serverless-trace`)
     restoreCwd()
-
-    const acceptableTargets = ['serverless', 'experimental-serverless-trace']
-    expect(utils.build.failBuild.mock.calls[0][0]).toEqual(
-      `next.config.js must be one of: ${acceptableTargets.join(', ')}`,
-    )
   })
 })
 


### PR DESCRIPTION
Under the hood, `utils.build.failBuild()` is throwing an error.
However, in tests, it is mocked with an empty function. This means the control flow continues because the code does not have any `return` statement after `failBuild()`. This means tests end up in odd situation where they are reaching lines of code that should never been hit in production.

This PR tries to fix this by:
  - Adding `return` statements after `utils.build.failBuild()`
  - Instead of mocking `utils.build.failBuild()`, replacing it with a simple function that throws an error. The tests then need to assert that an error is thrown from the `async onPreBuild` function, which is done in Jest with `await expect(onPreBuild(...)).rejects.toThrow('error message')`, as opposed to looking for mock calls.