### PR TITLE
Make Node.js support precise

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 14.x]
+        node-version: [10.13.0, 14.x]
         exclude:
           - os: macOS-latest
-            node-version: 10.x
+            node-version: 10.13.0
           - os: windows-latest
-            node-version: 10.x
+            node-version: 10.13.0
       fail-fast: false
 
     steps:

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
       "pre-commit": "prettier --check ."
     }
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "jest": {
     "testMatch": [
       "**/test/**/*.js",


### PR DESCRIPTION
Fixes #12.

This makes our Node.js support precise `>=10.13.0` since this is what Next.js 9 supports.