### PR TITLE
Improve `npm install` fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
 
     // TO-DO: Post alpha, try to remove this workaround for missing deps in
     // the next-on-netlify function template
-    await utils.run.command('npm install next-on-netlify@latest')
+    await utils.run.command('npm install next-aws-lambda')
 
     if (isStaticExportProject({ build, scripts })) {
       return failBuild(`** Static HTML export next.js projects do not require this plugin **`)


### PR DESCRIPTION
Discussion at https://github.com/netlify/netlify-plugin-nextjs/issues/10

The `npm install next-on-netlify` can be simplified to `npm install next-aws-lambda` instead (which should be slightly faster).
@lindsaylevine can you please confirm this still works?