### PR TITLE
Use new default functions directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 # Test
 test/sample/node_modules
 test/sample/out_functions
-test/sample/netlify-automatic-functions
+test/sample/netlify/functions
 test/sample/my-publish-dir
 test/sample/.next
 test/sample/.netlify

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you'd like to build and deploy your project using the [Netlify CLI](https://d
 2. Run any number of builds and deploys freely (i.e. `netlify build`, `netlify deploy --build`, `netlify deploy --prod`)
 3. Run `git stash --include-unstaged` to easily ignore plugin-generated files
 
-Plugin-generated files will output into either (a) the default functions and publish directories (`netlify-automatic-functions` and `.`, respectively) or (b) whichever custom functions and publish directories you configure. See below for custom directory configuration. It's important to note that, in both cases (a) and (b), the CLI may mix your project's source code and plugin-generated files; this is why we recommend committing all project source files before running CLI builds.
+Plugin-generated files will output into either (a) the default functions and publish directories (`netlify/functions` and `.`, respectively) or (b) whichever custom functions and publish directories you configure. See below for custom directory configuration. It's important to note that, in both cases (a) and (b), the CLI may mix your project's source code and plugin-generated files; this is why we recommend committing all project source files before running CLI builds.
 
 **Debugging CLI builds:**
 - If you're seeing a `{FILE_NAME} already exists` error running a CLI build, this may be because your `node_modules` got purged between builds or because of lingering unstashed files from outdated builds. To resolve, you need to manually remove any plugin-generated files from your project directory.

--- a/index.js
+++ b/index.js
@@ -85,4 +85,4 @@ module.exports = {
   },
 }
 
-const DEFAULT_FUNCTIONS_SRC = 'netlify-automatic-functions'
+const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'

--- a/test/index.js
+++ b/test/index.js
@@ -186,7 +186,7 @@ describe('onBuild()', () => {
 
   test.each([
     { FUNCTIONS_SRC: 'functions', resolvedFunctions: 'functions' },
-    { FUNCTIONS_SRC: undefined, resolvedFunctions: 'netlify-automatic-functions' },
+    { FUNCTIONS_SRC: undefined, resolvedFunctions: 'netlify/functions' },
   ])('copy files to the functions directory', async ({ FUNCTIONS_SRC, resolvedFunctions }) => {
     await useFixture('functions_copy_files')
     await moveNextDist()


### PR DESCRIPTION
With https://github.com/netlify/build/pull/2188, the default functions directory will be `netlify/functions`. This PR updates the plugin accordingly.