### PR TITLE
docs: add publish directory to netlify.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Read more about [UI-based plugin installation](https://docs.netlify.com/configur
     ```toml
     [build]
       command   = "npm run build"
+      publish = "out"
 
     [[plugins]]
       package = "@netlify/plugin-nextjs"


### PR DESCRIPTION
See https://netlify.slack.com/archives/C012GT6MYKU/p1611309758022200 and https://github.com/netlify/build/issues/2193

When creating a new site on Netlify, our UI looks in repo `netlify.toml` (if exists) and recommends a build command and publish directory based on its content.

Missing the `publish` setting causes our UI to recommend an empty directory (we'll follow up with another fix in our UI code).