### PR TITLE
chore: update setup-node github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
`actions/setup-node@v2` is more reliable as it uses a cache of Node.js releases (doesn't fail when Node.js site is down).
