### PR TITLE
fix: don't publish test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "files": [
     "helpers/**/*.js",
     "src",
-    "manifest.yml"
+    "manifest.yml",
+    "!src/cypress",
+    "!src/tests"
   ],
   "scripts": {
     "format": "prettier --write .",


### PR DESCRIPTION
I don't see a reason to publish these files, but I might be wrong.

Before:
```
npm notice package size:  74.1 kB                                 
npm notice unpacked size: 315.6 kB 
```

After:
```
npm notice package size:  24.6 kB                                 
npm notice unpacked size: 87.0 kB 
```