### PR TITLE
chore: add release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,14 @@
+name: release-please
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v2
+        with:
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
+          release-type: node
+          package-name: '@netlify/plugin-nextjs'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributions
+
+🎉 Thanks for considering contributing to this project! 🎉
+
+These guidelines will help you send a pull request.
+
+If you're submitting an issue instead, please skip this document.
+
+If your pull request is related to a typo or the documentation being unclear, please click on the relevant page's `Edit`
+button (pencil icon) and directly suggest a correction instead.
+
+This project was made with ❤️. The simplest way to give back is by starring and sharing it online.
+
+Everyone is welcome regardless of personal background. We enforce a [Code of conduct](CODE_OF_CONDUCT.md) in order to
+promote a positive and inclusive environment.
+
+## Development process
+
+First fork and clone the repository. If you're not sure how to do this, please watch
+[these videos](https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github).
+
+Run:
+
+```bash
+npm install
+```
+
+Make sure everything is correctly setup with:
+
+```bash
+npm test
+```
+
+## How to write commit messages
+
+We use [Conventional Commit messages](https://www.conventionalcommits.org/) to automate version management.
+
+Most common commit message prefixes are:
+
+* `fix:` which represents bug fixes, and generate a patch release.
+* `feat:` which represents a new feature, and generate a minor release.
+* `feat!:`, `fix!:` or `refactor!:` and generate a major release.
+
+## Releasing
+
+1. Merge the release PR
+2. Run `npm publish`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+# Releasing
+
+1. Merge the release PR
+2. Run `npm publish`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,0 @@
-# Releasing
-
-1. Merge the release PR
-2. Run `npm publish`

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,12 @@
     "cypress:local": "env CYPRESS_DEPLOY=local cypress run --project ./src --config-file false --config video=false",
     "cypress:netlify": "env CYPRESS_DEPLOY=netlify cypress run --project ./src --config-file false --config video=false",
     "cypress:local:testonly": "env CYPRESS_SKIP_DEPLOY=true npm run cypress:local",
-    "cypress:netlify:testonly": "env CYPRESS_SKIP_DEPLOY=true npm run cypress:netlify"
+    "cypress:netlify:testonly": "env CYPRESS_SKIP_DEPLOY=true npm run cypress:netlify",
+    "prepublishOnly": "run-s prepublishOnly:*",
+    "prepublishOnly:checkout": "git checkout main",
+    "prepublishOnly:pull": "git pull",
+    "prepublishOnly:install": "npm ci",
+    "prepublishOnly:test": "npm test"
   },
   "repository": {
     "type": "git",
@@ -70,6 +75,7 @@
   },
   "husky": {
     "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-commit": "prettier --check ."
     }
   },


### PR DESCRIPTION
This is what we use in our team for release automation.

It takes care of versioning, changelog generation, tagging and publishing GitHub releases.

On each commit to `main` `release-please` checks if there is something that justifies a release, based on conventional commit messages and then creates a relevant release PR (e.g https://github.com/netlify/cli/pull/1969).

Once the release PR is merged `release-please` tags the commit and creates a GitHub release.

To make this work, it requires writing commit messages in a specific way. See [here](https://github.com/googleapis/release-please#how-should-i-write-my-commits) for more information. 

There are other ways to automate releases, but we like this one as it doesn't require pushing directly to the default branch.

PR is at draft to get some feedback.