### PR TITLE
fix: fix missing `await` keyword

### DIFF
--- a/src/lib/pages/getStaticProps/setup.js
+++ b/src/lib/pages/getStaticProps/setup.js
@@ -38,7 +38,7 @@ const setup = async ({ functionsPath, publishPath }) => {
 
     // Skip if we have already set up a function for this file
     // or if the source route has a fallback (handled by getStaticPropsWithFallback)
-    if (filePathsDone.includes(filePath) || isRouteWithFallback(srcRoute)) return
+    if (filePathsDone.includes(filePath) || (await isRouteWithFallback(srcRoute))) return
 
     logItem(filePath)
     await setupNetlifyFunctionForPage({ filePath, functionsPath })


### PR DESCRIPTION
Fixes #116

`isRouteWithFallback()` was recently made async.

https://github.com/netlify/netlify-plugin-nextjs/blob/61b61f57d58ae095e3522c86013c75823911179b/src/lib/helpers/isRouteWithFallback.js#L3

However, one of its callers is missing the `await` keyword, which means it will always return `true`

https://github.com/netlify/netlify-plugin-nextjs/blob/61b61f57d58ae095e3522c86013c75823911179b/src/lib/pages/getStaticProps/setup.js#L41