### PR TITLE
fix: fix dynamic `require()` of `next`

### DIFF
--- a/helpers/validateNextUsage.js
+++ b/helpers/validateNextUsage.js
@@ -12,6 +12,8 @@ const validateNextUsage = function (failBuild) {
     )
   }
 
+  // We cannot load `next` at the top-level because we validate whether the
+  // site is using `next` inside `onPreBuild`.
   // Old Next.js versions are not supported
   const { version } = require('next/package.json')
   if (ltVersion(version, MIN_VERSION)) {

--- a/src/lib/helpers/getSortedRedirects.js
+++ b/src/lib/helpers/getSortedRedirects.js
@@ -1,4 +1,3 @@
-const { getSortedRoutes: getSortedRoutesFromNext } = require('next/dist/next-server/lib/router/utils/sorted-routes')
 const removeFileExtension = require('./removeFileExtension')
 
 // Return an array of redirects sorted in order of specificity, i.e., more generic
@@ -9,8 +8,11 @@ const getSortedRedirects = (redirects) => {
   // after sorting
   const routesWithoutExtensions = redirects.map(({ route }) => removeFileExtension(route))
 
+  // We cannot load `next` at the top-level because we validate whether the
+  // site is using `next` inside `onPreBuild`.
   // Sort the "naked" routes
-  const sortedRoutes = getSortedRoutesFromNext(routesWithoutExtensions)
+  const { getSortedRoutes } = require('next/dist/next-server/lib/router/utils/sorted-routes')
+  const sortedRoutes = getSortedRoutes(routesWithoutExtensions)
 
   // Return original routes in the sorted order
   return redirects.sort((a, b) => {


### PR DESCRIPTION
Partially addresses https://github.com/netlify/netlify-plugin-nextjs/issues/117

This ensures `next` is dynamically required.

Note: this does not address dynamically requiring `next` when `next.config.js` is loaded. A follow-up PR will fix this.