### PR TITLE
fix: fix `find-cache-dir` missing dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "chokidar": "^3.5.1",
         "commander": "^7.1.0",
         "debounce-fn": "^4.0.0",
+        "find-cache-dir": "^3.3.1",
         "find-up": "^4.1.0",
         "fs-extra": "^9.1.0",
         "jimp": "^0.16.1",
@@ -9000,8 +9001,7 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "node_modules/compare-func": {
       "version": "2.0.0",
@@ -12979,7 +12979,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
       "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-      "dev": true,
       "dependencies": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -20720,7 +20719,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -33515,8 +33513,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
+      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
     "compare-func": {
       "version": "2.0.0",
@@ -36792,7 +36789,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
       "integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
-      "dev": true,
       "requires": {
         "commondir": "^1.0.1",
         "make-dir": "^3.0.2",
@@ -43137,7 +43133,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
       "requires": {
         "find-up": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "chokidar": "^3.5.1",
     "commander": "^7.1.0",
     "debounce-fn": "^4.0.0",
+    "find-cache-dir": "^3.3.1",
     "find-up": "^4.1.0",
     "fs-extra": "^9.1.0",
     "jimp": "^0.16.1",


### PR DESCRIPTION
Fixes #126.

We use the `find-cache-dir` dependency but do not include it in our `package.json` `dependencies`.

https://github.com/netlify/netlify-plugin-nextjs/blob/61b61f57d58ae095e3522c86013c75823911179b/src/lib/steps/prepareFolders.js#L3

https://github.com/netlify/netlify-plugin-nextjs/blob/61b61f57d58ae095e3522c86013c75823911179b/src/lib/helpers/handleFileTracking.js#L3

This creates [the following bug](https://app.bugsnag.com/netlify/netlify-build/errors/6046b6b369f47b0018d4901a) in production:

```
Could not import plugin:
Cannot find module 'find-cache-dir'
Require stack:
- /opt/build/repo/.netlify/plugins/node_modules/@netlify/plugin-nextjs/src/lib/steps/prepareFolders.js
- /opt/build/repo/.netlify/plugins/node_modules/@netlify/plugin-nextjs/src/index.js
- /opt/build/repo/.netlify/plugins/node_modules/@netlify/plugin-nextjs/index.js
- /opt/buildhome/.netlify-build-nvm/versions/node/v12.16.3/lib/node_modules/@netlify/build/src/plugins/child/logic.js
- /opt/buildhome/.netlify-build-nvm/versions/node/v12.16.3/lib/node_modules/@netlify/build/src/plugins/child/load.js
- /opt/buildhome/.netlify-build-nvm/versions/node/v12.16.3/lib/node_modules/@netlify/build/src/plugins/child/main.js 
    internal/modules/cjs/loader.js:957:15 Function.Module._resolveFilename
    internal/modules/cjs/loader.js:840:27 Function.Module._load
    internal/modules/cjs/loader.js:1019:19 Module.require
    internal/modules/cjs/helpers.js:77:18 require
    /opt/build/repo/.netlify/plugins/node_modules/@netlify/plugin-nextjs/src/lib/steps/prepareFolders.js:3:22 Object.<anonymous>
    internal/modules/cjs/loader.js:1133:30 Module._compile
    internal/modules/cjs/loader.js:1153:10 Object.Module._extensions..js
    internal/modules/cjs/loader.js:977:32 Module.load
    internal/modules/cjs/loader.js:877:14 Function.Module._load
    internal/modules/cjs/loader.js:1019:19 Module.require
```

`find-cache-dir` is a dependency of `next`, so it turns out the module can still be required most of the times. However, there are cases where this is not the case, e.g. when `next` is not a site dependency (see https://github.com/netlify/netlify-plugin-nextjs/issues/117). 