### PR TITLE
fix: fix minimum Next.js version

### DIFF
--- a/helpers/validateNextUsage.js
+++ b/helpers/validateNextUsage.js
@@ -28,7 +28,7 @@ const validateNextUsage = function (failBuild) {
   }
 }
 
-const MIN_VERSION = '9.5.3'
+const MIN_VERSION = '10.0.6'
 const MIN_EXPERIMENTAL_VERSION = '11.0.0'
 
 const hasPackage = function (packageName) {


### PR DESCRIPTION
Fixes #130.

`next <10.0.6` is not expected to work with the current version of this plugin. Please let me know if this is not the case.