### PR TITLE
fix: backport `update failure points in plugin to do nothing instead` to v1

### DIFF
--- a/helpers/doesNotNeedPlugin.js
+++ b/helpers/doesNotNeedPlugin.js
@@ -1,0 +1,20 @@
+const findUp = require('find-up')
+
+// Checks all the cases for which the plugin should do nothing
+const isStaticExportProject = require('./isStaticExportProject')
+const doesSiteUseNextOnNetlify = require('./doesSiteUseNextOnNetlify')
+const hasCorrectNextConfig = require('./hasCorrectNextConfig')
+
+const doesNotNeedPlugin = async ({ netlifyConfig, packageJson }) => {
+  const { build } = netlifyConfig
+  const { name, scripts = {} } = packageJson
+  const nextConfigPath = await findUp('next.config.js')
+
+  return (
+    isStaticExportProject({ build, scripts }) ||
+    doesSiteUseNextOnNetlify({ packageJson }) ||
+    !hasCorrectNextConfig(nextConfigPath)
+  )
+}
+
+module.exports = doesNotNeedPlugin

--- a/helpers/doesSiteUseNextOnNetlify.js
+++ b/helpers/doesSiteUseNextOnNetlify.js
@@ -1,0 +1,20 @@
+// Checks if site is already using next-on-netlify
+const { name: pluginName } = require('../package.json')
+
+const doesSiteUseNextOnNetlify = ({ packageJson }) => {
+  const { name, scripts = {}, dependencies = {} } = packageJson
+
+  const hasNextOnNetlifyInstalled = dependencies['next-on-netlify'] !== undefined
+  const hasNextOnNetlifyPostbuildScript =
+    typeof scripts.postbuild === 'string' && scripts.postbuild.includes('next-on-netlify')
+  const isUsingNextOnNetlify = (hasNextOnNetlifyInstalled || hasNextOnNetlifyPostbuildScript) && pluginName !== name
+  if (isUsingNextOnNetlify) {
+    console.log(
+      `This plugin does not support sites that manually use next-on-netlify. Uninstall next-on-netlify as a dependency and/or remove it from your postbuild script to allow this plugin to run.`,
+    )
+  }
+
+  return isUsingNextOnNetlify
+}
+
+module.exports = doesSiteUseNextOnNetlify

--- a/helpers/hasCorrectNextConfig.js
+++ b/helpers/hasCorrectNextConfig.js
@@ -1,0 +1,27 @@
+const path = require('path')
+
+// Checks if site has the correct next.cofig.js
+const hasCorrectNextConfig = (nextConfigPath) => {
+  // In the plugin's case, no config is valid because we'll make it ourselves
+  if (nextConfigPath === undefined) return true
+
+  // We cannot load `next` at the top-level because we validate whether the
+  // site is using `next` inside `onPreBuild`.
+  const { PHASE_PRODUCTION_BUILD } = require('next/constants')
+  const { default: loadConfig } = require('next/dist/next-server/server/config')
+
+  // If the next config exists, log warning if target isnt in acceptableTargets
+  const acceptableTargets = ['serverless', 'experimental-serverless-trace']
+  const nextConfig = loadConfig(PHASE_PRODUCTION_BUILD, path.resolve('.'))
+  const isValidTarget = acceptableTargets.includes(nextConfig.target)
+  if (!isValidTarget) {
+    console.log(
+      `Your next.config.js must set the "target" property to one of: ${acceptableTargets.join(', ')}. Update the 
+      target property to allow this plugin to run.`,
+    )
+  }
+
+  return isValidTarget
+}
+
+module.exports = hasCorrectNextConfig

--- a/helpers/isStaticExportProject.js
+++ b/helpers/isStaticExportProject.js
@@ -1,7 +1,6 @@
 // Takes 1. Netlify config's build details and
 // 2. the project's package.json scripts to determine if
 // the Next.js app uses static HTML export
-
 const isStaticExportProject = ({ build, scripts }) => {
   const NEXT_EXPORT_COMMAND = 'next export'
 

--- a/helpers/validateNextUsage.js
+++ b/helpers/validateNextUsage.js
@@ -27,7 +27,7 @@ const validateNextUsage = function (failBuild) {
 }
 
 const MIN_VERSION = '9.5.3'
-const MIN_EXPERIMENTAL_VERSION = '10.0.0'
+const MIN_EXPERIMENTAL_VERSION = '11.0.0'
 
 const hasPackage = function (packageName) {
   try {

--- a/helpers/validateNextUsage.js
+++ b/helpers/validateNextUsage.js
@@ -27,7 +27,7 @@ const validateNextUsage = function (failBuild) {
 }
 
 const MIN_VERSION = '9.5.3'
-const MIN_EXPERIMENTAL_VERSION = '11.0.0'
+const MIN_EXPERIMENTAL_VERSION = '10.0.0'
 
 const hasPackage = function (packageName) {
   try {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,11 @@
 const fs = require('fs')
 const path = require('path')
 const util = require('util')
-
-const findUp = require('find-up')
 const makeDir = require('make-dir')
+const findUp = require('find-up')
 
-const { name: pluginName } = require('./package.json')
-const isStaticExportProject = require('./helpers/isStaticExportProject')
 const validateNextUsage = require('./helpers/validateNextUsage')
+const doesNotNeedPlugin = require('./helpers/doesNotNeedPlugin')
 
 const pWriteFile = util.promisify(fs.writeFile)
 
@@ -21,47 +19,17 @@ module.exports = {
 
     validateNextUsage(failBuild)
 
-    if (Object.keys(packageJson).length === 0) {
-      return failBuild(`Could not find a package.json for this project`)
+    const hasNoPackageJson = Object.keys(packageJson).length === 0
+    if (hasNoPackageJson) {
+      return failBuild('Could not find a package.json for this project')
     }
 
-    const { build } = netlifyConfig
-    const { name, scripts = {}, dependencies = {} } = packageJson
-
-    if (isStaticExportProject({ build, scripts })) {
-      return failBuild(
-        `Static HTML export Next.js projects do not require this plugin. Check your project's build command for 'next export'.`,
-      )
-    }
-
-    const hasNextOnNetlifyInstalled = dependencies['next-on-netlify'] !== undefined
-    const hasNextOnNetlifyPostbuildScript =
-      typeof scripts.postbuild === 'string' && scripts.postbuild.includes('next-on-netlify')
-    const isAlreadyUsingNextOnNetlify =
-      (hasNextOnNetlifyInstalled || hasNextOnNetlifyPostbuildScript) && pluginName !== name
-    if (isAlreadyUsingNextOnNetlify) {
-      return failBuild(
-        `This plugin does not support sites that manually use next-on-netlify. Uninstall next-on-netlify as a dependency to resolve.`,
-      )
+    if (await doesNotNeedPlugin({ netlifyConfig, packageJson })) {
+      return
     }
 
     const nextConfigPath = await findUp('next.config.js')
-    if (nextConfigPath !== undefined) {
-      // We cannot load `next` at the top-level because we validate whether the
-      // site is using `next` inside `onPreBuild`.
-      const { PHASE_PRODUCTION_BUILD } = require('next/constants')
-      const { default: loadConfig } = require('next/dist/next-server/server/config')
-
-      // If the next config exists, fail build if target isnt in acceptableTargets
-      const acceptableTargets = ['serverless', 'experimental-serverless-trace']
-      const nextConfig = loadConfig(PHASE_PRODUCTION_BUILD, path.resolve('.'))
-      const isValidTarget = acceptableTargets.includes(nextConfig.target)
-      if (!isValidTarget) {
-        return failBuild(
-          `Your next.config.js must set the "target" property to one of: ${acceptableTargets.join(', ')}`,
-        )
-      }
-    } else {
+    if (nextConfigPath === undefined) {
       // Create the next config file with target set to serverless by default
       const nextConfig = `
           module.exports = {
@@ -69,10 +37,13 @@ module.exports = {
           }
         `
       await pWriteFile('next.config.js', nextConfig)
-      console.log(`** Adding next.config.js with target set to 'serverless' **`)
     }
   },
-  async onBuild({ constants: { PUBLISH_DIR, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC } }) {
+  async onBuild({ netlifyConfig, packageJson, constants: { PUBLISH_DIR, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC } }) {
+    if (await doesNotNeedPlugin({ netlifyConfig, packageJson })) {
+      return
+    }
+
     console.log(`** Running Next on Netlify package **`)
 
     await makeDir(PUBLISH_DIR)


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-plugin-nextjs/issues/144

I created 2 branches out of the `v1.1.1` tag:
1. `release_v1.1.1` to represent the release.
2. `fix/backport_no_op` to represent the fix.

This PR cherry picks https://github.com/netlify/netlify-plugin-nextjs/commit/b2718f299e27603d4def10e0ff2f3f831d8b8f6e and wants to merge it from `fix/backport_no_op` to `release_v1.1.1` so we can cut a release from that branch.

I also kept the experimental version as `10.0.0` (see https://github.com/netlify/netlify-plugin-nextjs/commit/723be5d3cf6d1bbef3b4cedcf438afda58035d21)

I tested this locally and it works (I used https://github.com/erezrokah/next-starter-jamstack which is the starter with the update to Next.js 10 reverted)