### PR TITLE
refactor: locate next.config.js by root publish directory, instead of root of repository

### DIFF
--- a/helpers/defaultFailBuild.js
+++ b/helpers/defaultFailBuild.js
@@ -1,0 +1,3 @@
+exports.defaultFailBuild = function (message, { error }) {
+  throw new Error(`${message}\n${error.stack}`)
+}

--- a/helpers/getNextConfig.js
+++ b/helpers/getNextConfig.js
@@ -2,26 +2,23 @@
 
 const { resolve } = require('path')
 
+const { defaultFailBuild } = require('./defaultFailBuild')
 const moize = require('moize')
 
 // Load next.config.js
-const getNextConfig = async function (failBuild = defaultFailBuild) {
+const getNextConfig = async function (failBuild = defaultFailBuild, publishPath = '.') {
   // We cannot load `next` at the top-level because we validate whether the
   // site is using `next` inside `onPreBuild`.
   const { PHASE_PRODUCTION_BUILD } = require('next/constants')
   const loadConfig = require('next/dist/next-server/server/config').default
 
   try {
-    return await loadConfig(PHASE_PRODUCTION_BUILD, resolve('.'))
+    return await loadConfig(PHASE_PRODUCTION_BUILD, resolve(publishPath))
   } catch (error) {
     return failBuild('Error loading your next.config.js.', { error })
   }
 }
 
 const moizedGetNextConfig = moize(getNextConfig, { maxSize: 1e3, isPromise: true })
-
-const defaultFailBuild = function (message, { error }) {
-  throw new Error(`${message}\n${error.stack}`)
-}
 
 module.exports = moizedGetNextConfig

--- a/helpers/getNextConfig.js
+++ b/helpers/getNextConfig.js
@@ -21,6 +21,6 @@ const getNextConfig = async function (params = {}) {
   }
 }
 
-const moizedGetNextConfig = moize(getNextConfig, { maxSize: 1e3, isPromise: true })
+const moizedGetNextConfig = moize(getNextConfig, { maxSize: 1e3, isPromise: true, isDeepEqual: true })
 
 module.exports = moizedGetNextConfig

--- a/helpers/getNextConfig.js
+++ b/helpers/getNextConfig.js
@@ -6,7 +6,9 @@ const { defaultFailBuild } = require('./defaultFailBuild')
 const moize = require('moize')
 
 // Load next.config.js
-const getNextConfig = async function (failBuild = defaultFailBuild, publishPath = '.') {
+const getNextConfig = async function (params = {}) {
+  const { failBuild = defaultFailBuild, publishPath = '.' } = params
+
   // We cannot load `next` at the top-level because we validate whether the
   // site is using `next` inside `onPreBuild`.
   const { PHASE_PRODUCTION_BUILD } = require('next/constants')

--- a/helpers/hasCorrectNextConfig.js
+++ b/helpers/hasCorrectNextConfig.js
@@ -1,11 +1,11 @@
 const getNextConfig = require('./getNextConfig')
 
 // Checks if site has the correct next.config.js
-const hasCorrectNextConfig = async ({ nextConfigPath, failBuild }) => {
+const hasCorrectNextConfig = async ({ nextConfigPath, failBuild, publishPath }) => {
   // In the plugin's case, no config is valid because we'll make it ourselves
   if (nextConfigPath === undefined) return true
 
-  const { target } = await getNextConfig({ failBuild })
+  const { target } = await getNextConfig({ failBuild, publishPath })
 
   // If the next config exists, log warning if target isnt in acceptableTargets
   const acceptableTargets = ['serverless', 'experimental-serverless-trace']

--- a/helpers/hasCorrectNextConfig.js
+++ b/helpers/hasCorrectNextConfig.js
@@ -5,7 +5,7 @@ const hasCorrectNextConfig = async ({ nextConfigPath, failBuild }) => {
   // In the plugin's case, no config is valid because we'll make it ourselves
   if (nextConfigPath === undefined) return true
 
-  const { target } = await getNextConfig(failBuild)
+  const { target } = await getNextConfig({ failBuild })
 
   // If the next config exists, log warning if target isnt in acceptableTargets
   const acceptableTargets = ['serverless', 'experimental-serverless-trace']

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const build = async (functionsPath, publishPath) => {
 
   copyPublicFiles(publishPath)
 
-  await copyNextAssets(publishPath)
+  await copyNextAssets({ publishPath })
 
   await setupPages({ functionsPath, publishPath })
 

--- a/src/lib/helpers/addDefaultLocaleRedirect.js
+++ b/src/lib/helpers/addDefaultLocaleRedirect.js
@@ -3,8 +3,8 @@ const getI18n = require('./getI18n')
 // to the defaultLocale-prepended route i.e. /static -> /en/static
 // Note: there can only one defaultLocale, but we put it in an array to simplify
 // logic in redirects.js files via concatenation
-const addDefaultLocaleRedirect = async (redirects, route, target, additionalParams) => {
-  const i18n = await getI18n()
+const addDefaultLocaleRedirect = async ({ redirects, route, target, additionalParams, publishPath }) => {
+  const i18n = await getI18n({ publishPath })
   const { defaultLocale } = i18n
 
   // If no i18n, skip

--- a/src/lib/helpers/addLocaleRedirects.js
+++ b/src/lib/helpers/addLocaleRedirects.js
@@ -2,15 +2,15 @@ const getI18n = require('./getI18n')
 const getDataRouteForRoute = require('./getDataRouteForRoute')
 const asyncForEach = require('./asyncForEach')
 
-const addLocaleRedirects = async (redirects, route, target) => {
-  const i18n = await getI18n()
+const addLocaleRedirects = async ({ redirects, route, target, publishPath }) => {
+  const i18n = await getI18n({ publishPath })
   await asyncForEach(i18n.locales, async (locale) => {
     redirects.push({
       route: `/${locale}${route === '/' ? '' : route}`,
       target,
     })
     redirects.push({
-      route: await getDataRouteForRoute(route, locale),
+      route: await getDataRouteForRoute({ route, locale, publishPath }),
       target,
     })
   })

--- a/src/lib/helpers/copyDynamicImportChunks.js
+++ b/src/lib/helpers/copyDynamicImportChunks.js
@@ -4,8 +4,8 @@ const { logTitle } = require('../helpers/logger')
 const getNextDistDir = require('./getNextDistDir')
 
 // Check if there are dynamic import chunks and copy to the necessary function dir
-const copyDynamicImportChunks = async (functionPath) => {
-  const nextDistDir = await getNextDistDir()
+const copyDynamicImportChunks = async ({ functionPath, publishPath }) => {
+  const nextDistDir = await getNextDistDir({ publishPath })
   const chunksPath = join(nextDistDir, 'serverless')
   const files = readdirSync(chunksPath)
   const chunkRegex = new RegExp(/^(\.?[-_$~A-Z0-9a-z]+){1,}\.js$/g)

--- a/src/lib/helpers/getDataRouteForRoute.js
+++ b/src/lib/helpers/getDataRouteForRoute.js
@@ -14,8 +14,8 @@ const getI18nDataRoute = (route, locale, buildId) => {
 }
 
 // Return the data route for the given route
-const getDataRouteForRoute = async (route, locale) => {
-  const nextDistDir = await getNextDistDir()
+const getDataRouteForRoute = async ({ route, locale, publishPath }) => {
+  const nextDistDir = await getNextDistDir({ publishPath })
 
   // Get build ID that is used for data routes, e.g. /_next/data/BUILD_ID/...
   const fileContents = readFileSync(join(nextDistDir, 'BUILD_ID'))

--- a/src/lib/helpers/getI18n.js
+++ b/src/lib/helpers/getI18n.js
@@ -1,8 +1,8 @@
 // Get the i1i8n details specified in next.config.js, if any
 const getNextConfig = require('../../../helpers/getNextConfig')
 
-const getI18n = async () => {
-  const nextConfig = await getNextConfig()
+const getI18n = async ({ publishPath }) => {
+  const nextConfig = await getNextConfig({ publishPath })
 
   return nextConfig.i18n || { locales: [] }
 }

--- a/src/lib/helpers/getNextDistDir.js
+++ b/src/lib/helpers/getNextDistDir.js
@@ -5,7 +5,7 @@ const getNextConfig = require('../../../helpers/getNextConfig')
 const { defaultFailBuild } = require('../../../helpers/defaultFailBuild')
 
 const getNextDistDir = async (publishPath) => {
-  const nextConfig = await getNextConfig(defaultFailBuild, publishPath)
+  const nextConfig = await getNextConfig({ failBuild: defaultFailBuild, publishPath })
 
   return join('.', nextConfig.distDir)
 }

--- a/src/lib/helpers/getNextDistDir.js
+++ b/src/lib/helpers/getNextDistDir.js
@@ -3,7 +3,7 @@ const { join } = require('path')
 
 const getNextConfig = require('../../../helpers/getNextConfig')
 
-const getNextDistDir = async (publishPath) => {
+const getNextDistDir = async ({ publishPath }) => {
   const nextConfig = await getNextConfig({ publishPath })
 
   return join('.', nextConfig.distDir)

--- a/src/lib/helpers/getNextDistDir.js
+++ b/src/lib/helpers/getNextDistDir.js
@@ -1,9 +1,11 @@
 // Get the NextJS distDir specified in next.config.js
 const { join } = require('path')
-const getNextConfig = require('../../../helpers/getNextConfig')
 
-const getNextDistDir = async () => {
-  const nextConfig = await getNextConfig()
+const getNextConfig = require('../../../helpers/getNextConfig')
+const { defaultFailBuild } = require('../../../helpers/defaultFailBuild')
+
+const getNextDistDir = async (publishPath) => {
+  const nextConfig = await getNextConfig(defaultFailBuild, publishPath)
 
   return join('.', nextConfig.distDir)
 }

--- a/src/lib/helpers/getNextDistDir.js
+++ b/src/lib/helpers/getNextDistDir.js
@@ -2,10 +2,9 @@
 const { join } = require('path')
 
 const getNextConfig = require('../../../helpers/getNextConfig')
-const { defaultFailBuild } = require('../../../helpers/defaultFailBuild')
 
 const getNextDistDir = async (publishPath) => {
-  const nextConfig = await getNextConfig({ failBuild: defaultFailBuild, publishPath })
+  const nextConfig = await getNextConfig({ publishPath })
 
   return join('.', nextConfig.distDir)
 }

--- a/src/lib/helpers/getPagesManifest.js
+++ b/src/lib/helpers/getPagesManifest.js
@@ -2,8 +2,8 @@ const { join } = require('path')
 const { existsSync, readJSONSync } = require('fs-extra')
 const getNextDistDir = require('./getNextDistDir')
 
-const getPagesManifest = async () => {
-  const nextDistDir = await getNextDistDir()
+const getPagesManifest = async ({ publishPath }) => {
+  const nextDistDir = await getNextDistDir({ publishPath })
   const manifestPath = join(nextDistDir, 'serverless', 'pages-manifest.json')
   if (!existsSync(manifestPath)) return {}
   const contents = readJSONSync(manifestPath)

--- a/src/lib/helpers/getPrerenderManifest.js
+++ b/src/lib/helpers/getPrerenderManifest.js
@@ -5,7 +5,7 @@ const getNextDistDir = require('./getNextDistDir')
 const getDataRouteForRoute = require('./getDataRouteForRoute')
 const asyncForEach = require('./asyncForEach')
 
-const transformManifestForI18n = async (manifest) => {
+const transformManifestForI18n = async ({ manifest, publishPath }) => {
   const { routes } = manifest
   const newRoutes = {}
   await asyncForEach(Object.entries(routes), async ([route, { dataRoute, srcRoute, ...params }]) => {
@@ -16,7 +16,7 @@ const transformManifestForI18n = async (manifest) => {
       const locale = route.split('/')[1]
       const routeWithoutLocale = `/${route.split('/').slice(2, route.split('/').length).join('/')}`
       newRoutes[route] = {
-        dataRoute: await getDataRouteForRoute(routeWithoutLocale, locale),
+        dataRoute: await getDataRouteForRoute({ route: routeWithoutLocale, locale, publishPath }),
         srcRoute: routeWithoutLocale,
         ...params,
       }
@@ -26,11 +26,11 @@ const transformManifestForI18n = async (manifest) => {
   return { ...manifest, routes: newRoutes }
 }
 
-const getPrerenderManifest = async () => {
-  const nextConfig = await getNextConfig()
-  const nextDistDir = await getNextDistDir()
+const getPrerenderManifest = async ({ publishPath }) => {
+  const nextConfig = await getNextConfig({ publishPath })
+  const nextDistDir = await getNextDistDir({ publishPath })
   const manifest = readJSONSync(join(nextDistDir, 'prerender-manifest.json'))
-  if (nextConfig.i18n) return await transformManifestForI18n(manifest)
+  if (nextConfig.i18n) return await transformManifestForI18n({ manifest, publishPath })
   return manifest
 }
 

--- a/src/lib/helpers/getRoutesManifest.js
+++ b/src/lib/helpers/getRoutesManifest.js
@@ -2,8 +2,8 @@ const { join } = require('path')
 const { readJSONSync } = require('fs-extra')
 const getNextDistDir = require('./getNextDistDir')
 
-const getRoutesManifest = async () => {
-  const nextDistDir = await getNextDistDir()
+const getRoutesManifest = async ({ publishPath }) => {
+  const nextDistDir = await getNextDistDir({ publishPath })
   return readJSONSync(join(nextDistDir, 'routes-manifest.json'))
 }
 

--- a/src/lib/helpers/isRouteInPrerenderManifest.js
+++ b/src/lib/helpers/isRouteInPrerenderManifest.js
@@ -2,10 +2,10 @@ const getPrerenderManifest = require('./getPrerenderManifest')
 const getI18n = require('./getI18n')
 
 // Return true if the route is defined in the prerender manifest
-const isRouteInPrerenderManifest = async (route) => {
-  const i18n = await getI18n()
+const isRouteInPrerenderManifest = async ({ route, publishPath }) => {
+  const i18n = await getI18n({ publishPath })
   const { defaultLocale, locales } = i18n
-  const { routes, dynamicRoutes } = await getPrerenderManifest()
+  const { routes, dynamicRoutes } = await getPrerenderManifest({ publishPath })
 
   const isRouteInManifestWithI18n = () => {
     let isStaticRoute = false
@@ -16,7 +16,7 @@ const isRouteInPrerenderManifest = async (route) => {
     return isStaticRoute || route in dynamicRoutes
   }
 
-  if (i18n.defaultLocale) return isRouteInManifestWithI18n(route)
+  if (i18n.defaultLocale) return isRouteInManifestWithI18n()
   return route in routes || route in dynamicRoutes
 }
 

--- a/src/lib/helpers/isRouteWithDataRoute.js
+++ b/src/lib/helpers/isRouteWithDataRoute.js
@@ -1,8 +1,8 @@
 const getRoutesManifest = require('./getRoutesManifest')
 
 // Return true if the route has a data route in the routes manifest
-const isRouteWithDataRoute = async (route) => {
-  const { dataRoutes } = await getRoutesManifest()
+const isRouteWithDataRoute = async ({ route, publishPath }) => {
+  const { dataRoutes } = await getRoutesManifest({ publishPath })
 
   // If no data routes exist, return false
   if (dataRoutes == null) return false

--- a/src/lib/helpers/isRouteWithFallback.js
+++ b/src/lib/helpers/isRouteWithFallback.js
@@ -1,7 +1,7 @@
 const getPrerenderManifest = require('./getPrerenderManifest')
 
-const isRouteWithFallback = async (route) => {
-  const { dynamicRoutes } = await getPrerenderManifest()
+const isRouteWithFallback = async ({ route, publishPath }) => {
+  const { dynamicRoutes } = await getPrerenderManifest({ publishPath })
 
   // Fallback "blocking" routes will have fallback: null in manifest
   return dynamicRoutes[route] && dynamicRoutes[route].fallback !== false

--- a/src/lib/helpers/setupNetlifyFunctionForPage.js
+++ b/src/lib/helpers/setupNetlifyFunctionForPage.js
@@ -7,7 +7,7 @@ const copyDynamicImportChunks = require('./copyDynamicImportChunks')
 const { logItem } = require('./logger')
 
 // Create a Netlify Function for the page with the given file path
-const setupNetlifyFunctionForPage = async ({ filePath, functionsPath, isApiPage }) => {
+const setupNetlifyFunctionForPage = async ({ filePath, functionsPath, isApiPage, publishPath }) => {
   // Set function name based on file path
   const functionName = getNetlifyFunctionName(filePath, isApiPage)
   const functionDirectory = join(functionsPath, functionName)
@@ -33,11 +33,11 @@ const setupNetlifyFunctionForPage = async ({ filePath, functionsPath, isApiPage 
   })
 
   // Copy any dynamic import chunks
-  await copyDynamicImportChunks(functionDirectory)
+  await copyDynamicImportChunks({ functionPath: functionDirectory, publishPath })
 
   // Copy page
   const nextPageCopyPath = join(functionDirectory, 'nextPage', 'index.js')
-  const nextDistDir = await getNextDistDir()
+  const nextDistDir = await getNextDistDir({ publishPath })
   copySync(join(nextDistDir, 'serverless', filePath), nextPageCopyPath, {
     overwrite: false,
     errorOnExist: true,

--- a/src/lib/helpers/setupStaticFileForPage.js
+++ b/src/lib/helpers/setupStaticFileForPage.js
@@ -7,7 +7,7 @@ const setupStaticFileForPage = async ({ inputPath, outputPath = null, publishPat
   // If no outputPath is set, default to the same as inputPath
   outputPath = outputPath || inputPath
 
-  const nextDistDir = await getNextDistDir()
+  const nextDistDir = await getNextDistDir({ publishPath })
 
   // Perform copy operation
   copySync(join(nextDistDir, 'serverless', 'pages', inputPath), join(publishPath, outputPath), {

--- a/src/lib/pages/api/pages.js
+++ b/src/lib/pages/api/pages.js
@@ -1,9 +1,9 @@
 const getPagesManifest = require('../../helpers/getPagesManifest')
 const isApiRoute = require('../../helpers/isApiRoute')
 
-const getPages = async () => {
+const getPages = async ({ publishPath }) => {
   // Get HTML and SSR pages and API endpoints from the NextJS pages manifest
-  const pagesManifest = await getPagesManifest()
+  const pagesManifest = await getPagesManifest({ publishPath })
 
   // Collect pages
   const pages = []

--- a/src/lib/pages/api/redirects.js
+++ b/src/lib/pages/api/redirects.js
@@ -1,8 +1,8 @@
 const getNetlifyFunctionName = require('../../helpers/getNetlifyFunctionName')
 const getPages = require('./pages')
 
-const getRedirects = async () => {
-  const pages = await getPages()
+const getRedirects = async ({ publishPath }) => {
+  const pages = await getPages({ publishPath })
   return pages.map(({ route, filePath }) => ({
     route,
     target: `/.netlify/functions/${getNetlifyFunctionName(filePath, true)}`,

--- a/src/lib/pages/api/setup.js
+++ b/src/lib/pages/api/setup.js
@@ -4,15 +4,15 @@ const asyncForEach = require('../../helpers/asyncForEach')
 const getPages = require('./pages')
 
 // Create a Netlify Function for every API endpoint
-const setup = async (functionsPath) => {
+const setup = async ({ functionsPath, publishPath }) => {
   logTitle('💫 Setting up API endpoints as Netlify Functions in', functionsPath)
 
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   // Create Netlify Function for every page
   await asyncForEach(pages, async ({ filePath }) => {
     logItem(filePath)
-    await setupNetlifyFunctionForPage({ filePath, functionsPath, isApiPage: true })
+    await setupNetlifyFunctionForPage({ filePath, functionsPath, isApiPage: true, publishPath })
   })
 }
 

--- a/src/lib/pages/getInitialProps/pages.js
+++ b/src/lib/pages/getInitialProps/pages.js
@@ -6,9 +6,9 @@ const isRouteInPrerenderManifest = require('../../helpers/isRouteInPrerenderMani
 const isRouteWithDataRoute = require('../../helpers/isRouteWithDataRoute')
 const asyncForEach = require('../../helpers/asyncForEach')
 
-const getPages = async () => {
+const getPages = async ({ publishPath }) => {
   // Get HTML and SSR pages and API endpoints from the NextJS pages manifest
-  const pagesManifest = await getPagesManifest()
+  const pagesManifest = await getPagesManifest({ publishPath })
 
   // Collect pages
   const pages = []
@@ -25,11 +25,11 @@ const getPages = async () => {
     if (isApiRoute(route)) return
 
     // Skip page if it is actually used with getStaticProps
-    if (await isRouteInPrerenderManifest(route)) return
+    if (await isRouteInPrerenderManifest({ route, publishPath })) return
 
     // Skip page if it has a data route (because then it is a page with
     // getServerSideProps)
-    if (await isRouteWithDataRoute(route)) return
+    if (await isRouteWithDataRoute({ route, publishPath })) return
 
     // Add page
     pages.push({ route, filePath })

--- a/src/lib/pages/getInitialProps/redirects.js
+++ b/src/lib/pages/getInitialProps/redirects.js
@@ -3,15 +3,15 @@ const getNetlifyFunctionName = require('../../helpers/getNetlifyFunctionName')
 const asyncForEach = require('../../helpers/asyncForEach')
 const getPages = require('./pages')
 
-const getRedirects = async () => {
+const getRedirects = async ({ publishPath }) => {
   const redirects = []
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, filePath }) => {
     const functionName = getNetlifyFunctionName(filePath)
     const target = `/.netlify/functions/${functionName}`
 
-    await addLocaleRedirects(redirects, route, target)
+    await addLocaleRedirects({ redirects, route, target, publishPath })
 
     redirects.push({
       route,

--- a/src/lib/pages/getInitialProps/setup.js
+++ b/src/lib/pages/getInitialProps/setup.js
@@ -4,15 +4,15 @@ const asyncForEach = require('../../helpers/asyncForEach')
 const getPages = require('./pages')
 
 // Create a Netlify Function for every page with getInitialProps
-const setup = async (functionsPath) => {
+const setup = async ({ functionsPath, publishPath }) => {
   logTitle('💫 Setting up pages with getInitialProps as Netlify Functions in', functionsPath)
 
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   // Create Netlify Function for every page
   await asyncForEach(pages, async ({ filePath }) => {
     logItem(filePath)
-    await setupNetlifyFunctionForPage({ filePath, functionsPath })
+    await setupNetlifyFunctionForPage({ filePath, functionsPath, publishPath })
   })
 }
 

--- a/src/lib/pages/getServerSideProps/pages.js
+++ b/src/lib/pages/getServerSideProps/pages.js
@@ -6,12 +6,12 @@ const isApiRoute = require('../../helpers/isApiRoute')
 const isRouteInPrerenderManifest = require('../../helpers/isRouteInPrerenderManifest')
 const isRouteWithDataRoute = require('../../helpers/isRouteWithDataRoute')
 
-const getPages = async () => {
+const getPages = async ({ publishPath }) => {
   // Collect pages
   const pages = []
 
   // Get HTML and SSR pages and API endpoints from the NextJS pages manifest
-  const pagesManifest = await getPagesManifest()
+  const pagesManifest = await getPagesManifest({ publishPath })
 
   // Parse pages
   await asyncForEach(Object.entries(pagesManifest), async ([route, filePath]) => {
@@ -25,12 +25,12 @@ const getPages = async () => {
     if (isApiRoute(route)) return
 
     // Skip page if it is actually used with getStaticProps
-    const isInPrerenderManifest = await isRouteInPrerenderManifest(route)
+    const isInPrerenderManifest = await isRouteInPrerenderManifest({ route, publishPath })
     if (isInPrerenderManifest) return
 
     // Skip page if it has no data route (because then it is a page with
     // getInitialProps)
-    const hasDataRoute = await isRouteWithDataRoute(route)
+    const hasDataRoute = await isRouteWithDataRoute({ route, publishPath })
     if (!hasDataRoute) return
 
     // Add page

--- a/src/lib/pages/getServerSideProps/redirects.js
+++ b/src/lib/pages/getServerSideProps/redirects.js
@@ -12,15 +12,15 @@ const getPages = require('./pages')
  * }
  **/
 
-const getRedirects = async () => {
+const getRedirects = async ({ publishPath }) => {
   const redirects = []
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, filePath }) => {
     const functionName = getNetlifyFunctionName(filePath)
     const target = `/.netlify/functions/${functionName}`
 
-    await addLocaleRedirects(redirects, route, target)
+    await addLocaleRedirects({ redirects, route, target, publishPath })
 
     // Add one redirect for the naked route
     // i.e. /ssr
@@ -33,7 +33,7 @@ const getRedirects = async () => {
     // pages-manifest doesn't provide the dataRoute for us so we
     // construct it ourselves with getDataRouteForRoute
     redirects.push({
-      route: await getDataRouteForRoute(route),
+      route: await getDataRouteForRoute({ route, publishPath }),
       target,
     })
   })

--- a/src/lib/pages/getServerSideProps/setup.js
+++ b/src/lib/pages/getServerSideProps/setup.js
@@ -4,15 +4,15 @@ const asyncForEach = require('../../helpers/asyncForEach')
 const getPages = require('./pages')
 
 // Create a Netlify Function for every page with getServerSideProps
-const setup = async (functionsPath) => {
+const setup = async ({ functionsPath, publishPath }) => {
   logTitle('💫 Setting up pages with getServerSideProps as Netlify Functions in', functionsPath)
 
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   // Create Netlify Function for every page
   await asyncForEach(pages, async ({ filePath }) => {
     logItem(filePath)
-    await setupNetlifyFunctionForPage({ filePath, functionsPath })
+    await setupNetlifyFunctionForPage({ filePath, functionsPath, publishPath })
   })
 }
 

--- a/src/lib/pages/getStaticProps/pages.js
+++ b/src/lib/pages/getStaticProps/pages.js
@@ -1,8 +1,8 @@
 const getPrerenderManifest = require('../../helpers/getPrerenderManifest')
 
 // Get pages using getStaticProps
-const getPages = async () => {
-  const { routes } = await getPrerenderManifest()
+const getPages = async ({ publishPath }) => {
+  const { routes } = await getPrerenderManifest({ publishPath })
 
   // Collect pages
   const pages = []

--- a/src/lib/pages/getStaticProps/redirects.js
+++ b/src/lib/pages/getStaticProps/redirects.js
@@ -23,9 +23,9 @@ const getPages = require('./pages')
 
 // Pages with getStaticProps (without fallback or revalidation) only need
 // redirects for i18n and handling preview mode
-const getRedirects = async () => {
+const getRedirects = async ({ publishPath }) => {
   const redirects = []
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, dataRoute, srcRoute }) => {
     const relativePath = getFilePathForRoute(srcRoute || route, 'js')
@@ -50,8 +50,8 @@ const getRedirects = async () => {
     })
 
     // Preview mode default locale redirect must precede normal default locale redirect
-    await addDefaultLocaleRedirect(redirects, route, target, previewModeRedirect)
-    await addDefaultLocaleRedirect(redirects, route)
+    await addDefaultLocaleRedirect({ redirects, route, target, additionalParams: previewModeRedirect, publishPath })
+    await addDefaultLocaleRedirect({ redirects, route, publishPath })
   })
 
   return redirects

--- a/src/lib/pages/getStaticProps/setup.js
+++ b/src/lib/pages/getStaticProps/setup.js
@@ -15,7 +15,7 @@ const setup = async ({ functionsPath, publishPath }) => {
   // a function for the same file path twice
   const filePathsDone = []
 
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, dataRoute, srcRoute }) => {
     logItem(route)
@@ -38,10 +38,10 @@ const setup = async ({ functionsPath, publishPath }) => {
 
     // Skip if we have already set up a function for this file
     // or if the source route has a fallback (handled by getStaticPropsWithFallback)
-    if (filePathsDone.includes(filePath) || (await isRouteWithFallback(srcRoute))) return
+    if (filePathsDone.includes(filePath) || (await isRouteWithFallback({ route: srcRoute, publishPath }))) return
 
     logItem(filePath)
-    await setupNetlifyFunctionForPage({ filePath, functionsPath })
+    await setupNetlifyFunctionForPage({ filePath, functionsPath, publishPath })
     filePathsDone.push(filePath)
   })
 }

--- a/src/lib/pages/getStaticPropsWithFallback/pages.js
+++ b/src/lib/pages/getStaticPropsWithFallback/pages.js
@@ -1,8 +1,8 @@
 const getPrerenderManifest = require('../../helpers/getPrerenderManifest')
 
 // Get pages using getStaticProps
-const getPages = async () => {
-  const { dynamicRoutes } = await getPrerenderManifest()
+const getPages = async ({ publishPath }) => {
+  const { dynamicRoutes } = await getPrerenderManifest({ publishPath })
 
   // Collect pages
   const pages = []

--- a/src/lib/pages/getStaticPropsWithFallback/redirects.js
+++ b/src/lib/pages/getStaticPropsWithFallback/redirects.js
@@ -5,9 +5,9 @@ const getNetlifyFunctionName = require('../../helpers/getNetlifyFunctionName')
 const getPages = require('./pages')
 const asyncForEach = require('../../helpers/asyncForEach')
 
-const getRedirects = async () => {
+const getRedirects = async ({ publishPath }) => {
   const redirects = []
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, dataRoute }) => {
     const relativePath = getFilePathForRoute(route, 'js')
@@ -15,7 +15,7 @@ const getRedirects = async () => {
     const functionName = getNetlifyFunctionName(filePath)
     const target = `/.netlify/functions/${functionName}`
 
-    await addLocaleRedirects(redirects, route, target)
+    await addLocaleRedirects({ redirects, route, target, publishPath })
 
     // Add one redirect for the page
     redirects.push({

--- a/src/lib/pages/getStaticPropsWithFallback/setup.js
+++ b/src/lib/pages/getStaticPropsWithFallback/setup.js
@@ -6,17 +6,17 @@ const asyncForEach = require('../../helpers/asyncForEach')
 const getPages = require('./pages')
 
 // Create a Netlify Function for every page with getStaticProps and fallback
-const setup = async (functionsPath) => {
+const setup = async ({ functionsPath, publishPath }) => {
   logTitle('💫 Setting up pages with getStaticProps and fallback: true', 'as Netlify Functions in', functionsPath)
 
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   // Create Netlify Function for every page
   await asyncForEach(pages, async ({ route }) => {
     const relativePath = getFilePathForRoute(route, 'js')
     const filePath = join('pages', relativePath)
     logItem(filePath)
-    await setupNetlifyFunctionForPage({ filePath, functionsPath })
+    await setupNetlifyFunctionForPage({ filePath, functionsPath, publishPath })
   })
 }
 

--- a/src/lib/pages/getStaticPropsWithRevalidate/pages.js
+++ b/src/lib/pages/getStaticPropsWithRevalidate/pages.js
@@ -3,8 +3,8 @@ const getPrerenderManifest = require('../../helpers/getPrerenderManifest')
 const asyncForEach = require('../../helpers/asyncForEach')
 
 // Get pages using getStaticProps
-const getPages = async () => {
-  const { routes } = await getPrerenderManifest()
+const getPages = async ({ publishPath }) => {
+  const { routes } = await getPrerenderManifest({ publishPath })
 
   // Collect pages
   const pages = []
@@ -15,7 +15,7 @@ const getPages = async () => {
 
     // Skip pages with fallback, these are handled by
     // getStaticPropsWithFallback/pages
-    if (await isRouteWithFallback(srcRoute)) return
+    if (await isRouteWithFallback({ route: srcRoute, publishPath })) return
 
     // Add the page
     pages.push({

--- a/src/lib/pages/getStaticPropsWithRevalidate/redirects.js
+++ b/src/lib/pages/getStaticPropsWithRevalidate/redirects.js
@@ -20,9 +20,9 @@ const getPages = require('./pages')
  * }
  **/
 
-const getRedirects = async () => {
+const getRedirects = async ({ publishPath }) => {
   const redirects = []
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, srcRoute, dataRoute }) => {
     const relativePath = getFilePathForRoute(srcRoute || route, 'js')
@@ -42,7 +42,7 @@ const getRedirects = async () => {
       target,
     })
 
-    await addDefaultLocaleRedirect(redirects, route, target)
+    await addDefaultLocaleRedirect({ redirects, route, target, publishPath })
   })
 
   return redirects

--- a/src/lib/pages/getStaticPropsWithRevalidate/setup.js
+++ b/src/lib/pages/getStaticPropsWithRevalidate/setup.js
@@ -6,7 +6,7 @@ const asyncForEach = require('../../helpers/asyncForEach')
 const getPages = require('./pages')
 
 // Create a Netlify Function for every page with getStaticProps and revalidate
-const setup = async (functionsPath) => {
+const setup = async ({ functionsPath, publishPath }) => {
   logTitle(
     '💫 Setting up pages with getStaticProps and revalidation interval',
     'as Netlify Functions in',
@@ -17,7 +17,7 @@ const setup = async (functionsPath) => {
   // a function for the same file path twice
   const filePathsDone = []
 
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   // Create Netlify Function for every page
   await asyncForEach(pages, async ({ route, srcRoute }) => {
@@ -29,7 +29,7 @@ const setup = async (functionsPath) => {
 
     // Set up the function
     logItem(filePath)
-    await setupNetlifyFunctionForPage({ filePath, functionsPath })
+    await setupNetlifyFunctionForPage({ filePath, functionsPath, publishPath })
     filePathsDone.push(filePath)
   })
 }

--- a/src/lib/pages/withoutProps/pages.js
+++ b/src/lib/pages/withoutProps/pages.js
@@ -4,11 +4,11 @@ const isRouteInPrerenderManifest = require('../../helpers/isRouteInPrerenderMani
 const asyncForEach = require('../../helpers/asyncForEach')
 
 // Collect pages
-const getPages = async () => {
+const getPages = async ({ publishPath }) => {
   const pages = []
 
   // Get HTML and SSR pages and API endpoints from the NextJS pages manifest
-  const pagesManifest = await getPagesManifest()
+  const pagesManifest = await getPagesManifest({ publishPath })
 
   // Parse HTML pages
   await asyncForEach(Object.entries(pagesManifest), async ([route, filePath]) => {
@@ -16,7 +16,7 @@ const getPages = async () => {
     if (!isHtmlFile(filePath)) return
 
     // Skip page if it is actually used with getStaticProps
-    if (await isRouteInPrerenderManifest(route)) return
+    if (await isRouteInPrerenderManifest({ route, publishPath })) return
 
     // Add the HTML page
     pages.push({ route, filePath })

--- a/src/lib/pages/withoutProps/redirects.js
+++ b/src/lib/pages/withoutProps/redirects.js
@@ -16,14 +16,14 @@ const getPages = require('./pages')
  * }
  **/
 
-const getRedirects = async () => {
+const getRedirects = async ({ publishPath }) => {
   const redirects = []
-  const pages = await getPages()
+  const pages = await getPages({ publishPath })
 
   await asyncForEach(pages, async ({ route, filePath }) => {
     const target = filePath.replace(/pages/, '')
 
-    await addDefaultLocaleRedirect(redirects, route, target)
+    await addDefaultLocaleRedirect({ redirects, route, target, publishPath })
 
     // Only create normal redirects for pages with dynamic routing
     if (!isDynamicRoute(route)) return

--- a/src/lib/pages/withoutProps/setup.js
+++ b/src/lib/pages/withoutProps/setup.js
@@ -9,12 +9,12 @@ const getPages = require('./pages')
 
 // Identify all pages that have been pre-rendered and copy each one to the
 // Netlify publish directory.
-const setup = async (publishPath) => {
+const setup = async ({ publishPath }) => {
   logTitle('🔥 Copying pre-rendered pages without props to', publishPath)
 
-  const i18n = await getI18n()
-  const nextDistDir = await getNextDistDir()
-  const pages = await getPages()
+  const i18n = await getI18n({ publishPath })
+  const nextDistDir = await getNextDistDir({ publishPath })
+  const pages = await getPages({ publishPath })
 
   // Copy each page to the Netlify publish directory
   await asyncForEach(pages, async ({ filePath }) => {

--- a/src/lib/steps/copyNextAssets.js
+++ b/src/lib/steps/copyNextAssets.js
@@ -5,8 +5,8 @@ const getNextDistDir = require('../helpers/getNextDistDir')
 
 // Copy the NextJS' static assets from NextJS distDir to Netlify publish folder.
 // These need to be available for NextJS to work.
-const copyNextAssets = async (publishPath) => {
-  const nextDistDir = await getNextDistDir(publishPath)
+const copyNextAssets = async ({ publishPath }) => {
+  const nextDistDir = await getNextDistDir({ publishPath })
   const staticAssetsPath = join(nextDistDir, 'static')
   if (!existsSync(staticAssetsPath)) {
     throw new Error(

--- a/src/lib/steps/copyNextAssets.js
+++ b/src/lib/steps/copyNextAssets.js
@@ -6,7 +6,7 @@ const getNextDistDir = require('../helpers/getNextDistDir')
 // Copy the NextJS' static assets from NextJS distDir to Netlify publish folder.
 // These need to be available for NextJS to work.
 const copyNextAssets = async (publishPath) => {
-  const nextDistDir = await getNextDistDir()
+  const nextDistDir = await getNextDistDir(publishPath)
   const staticAssetsPath = join(nextDistDir, 'static')
   if (!existsSync(staticAssetsPath)) {
     throw new Error(

--- a/src/lib/steps/setupPages.js
+++ b/src/lib/steps/setupPages.js
@@ -8,13 +8,13 @@ const withoutPropsSetup = require('../pages/withoutProps/setup')
 
 // Set up all our NextJS pages according to the recipes defined in pages/
 const setupPages = async ({ functionsPath, publishPath }) => {
-  await apiSetup(functionsPath)
-  await getInitialPropsSetup(functionsPath)
-  await getServerSidePropsSetup(functionsPath)
+  await apiSetup({ functionsPath, publishPath })
+  await getInitialPropsSetup({ functionsPath, publishPath })
+  await getServerSidePropsSetup({ functionsPath, publishPath })
   await getStaticPropsSetup({ functionsPath, publishPath })
-  await getSPFallbackSetup(functionsPath)
-  await getSPRevalidateSetup(functionsPath)
-  await withoutPropsSetup(publishPath)
+  await getSPFallbackSetup({ functionsPath, publishPath })
+  await getSPRevalidateSetup({ functionsPath, publishPath })
+  await withoutPropsSetup({ publishPath })
 }
 
 module.exports = setupPages

--- a/src/lib/steps/setupRedirects.js
+++ b/src/lib/steps/setupRedirects.js
@@ -30,13 +30,13 @@ const setupRedirects = async (publishPath) => {
   const getWithoutPropsRedirects = require('../pages/withoutProps/redirects')
 
   const nextRedirects = [
-    ...(await getApiRedirects()),
-    ...(await getInitialPropsRedirects()),
-    ...(await getServerSidePropsRedirects()),
-    ...(await getStaticPropsRedirects()),
-    ...(await getSPFallbackRedirects()),
-    ...(await getSPRevalidateRedirects()),
-    ...(await getWithoutPropsRedirects()),
+    ...(await getApiRedirects({ publishPath })),
+    ...(await getInitialPropsRedirects({ publishPath })),
+    ...(await getServerSidePropsRedirects({ publishPath })),
+    ...(await getStaticPropsRedirects({ publishPath })),
+    ...(await getSPFallbackRedirects({ publishPath })),
+    ...(await getSPRevalidateRedirects({ publishPath })),
+    ...(await getWithoutPropsRedirects({ publishPath })),
   ]
 
   // Add _redirect section heading


### PR DESCRIPTION
Description
---

This PR should solves #115 to handle edge cases when user build Netlify site and export `.next` and `next.config.js` to somewhere else. In case of Nx after build is succeed, `next.config` and `.next` is generated in `dists/apps/<application name>` which is nessesary to use this plugin  but current code still always looking `next.config.js` in root repository causing builds to failed due to plugin error.

https://github.com/netlify/netlify-plugin-nextjs/blob/2f564b151552358689ea578563a52f2713345ccd/helpers/getNextConfig.js#L15