### PR TITLE
fix: refactor image function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,8 @@
         "find-cache-dir": "^3.3.1",
         "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
+        "image-type": "^4.1.0",
+        "is-svg": "^4.3.1",
         "make-dir": "^3.1.0",
         "mime-types": "^2.1.30",
         "moize": "^6.0.0",
@@ -10025,6 +10027,14 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-type": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -11103,6 +11113,17 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/image-type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-4.1.0.tgz",
+      "integrity": "sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==",
+      "dependencies": {
+        "file-type": "^10.10.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -11750,6 +11771,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-svg": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.3.1.tgz",
+      "integrity": "sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==",
+      "dependencies": {
+        "fast-xml-parser": "^3.19.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-symbol": {
@@ -46927,6 +46962,11 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-type": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-10.11.0.tgz",
+      "integrity": "sha512-uzk64HRpUZyTGZtVuvrjP0FYxzQrBf4rojot6J65YMEbwBLB0CWm0CLojVpwpmFmxcE/lkvYICgfcGozbBq6rw=="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -47726,6 +47766,14 @@
       "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
       "peer": true
     },
+    "image-type": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/image-type/-/image-type-4.1.0.tgz",
+      "integrity": "sha512-CFJMJ8QK8lJvRlTCEgarL4ro6hfDQKif2HjSvYCdQZESaIPV4v9imrf7BQHK+sQeTeNeMpWciR9hyC/g8ybXEg==",
+      "requires": {
+        "file-type": "^10.10.0"
+      }
+    },
     "import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -48170,6 +48218,14 @@
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
       "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
       "dev": true
+    },
+    "is-svg": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/is-svg/-/is-svg-4.3.1.tgz",
+      "integrity": "sha512-h2CGs+yPUyvkgTJQS9cJzo9lYK06WgRiXUqBBHtglSzVKAuH4/oWsqk7LGfbSa1hGk9QcZ0SyQtVggvBA8LZXA==",
+      "requires": {
+        "fast-xml-parser": "^3.19.0"
+      }
     },
     "is-symbol": {
       "version": "1.0.4",
@@ -50868,7 +50924,6 @@
       "integrity": "sha512-HcZ0RWQRuJfpPiaHyFQJzcym+/dDIVUPwUAXWoub/C4GkGu+mPjp8vqK6g0FxokCnnI2TK0gZTza2IDfiNNscQ==",
       "peer": true,
       "requires": {
-        "@babel/core": "^7.0.0",
         "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-export-default-from": "^7.0.0",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.0.0",
@@ -50923,7 +50978,6 @@
       "integrity": "sha512-K1sHO3ODBFCr7uEiCQ4RvVr+cQg0EHQF8ChVPnecGh/WDD8udrTq9ECwB0dRfMjAvlsHtRUlJm6ZSI8UPgum2w==",
       "peer": true,
       "requires": {
-        "@babel/core": "^7.0.0",
         "babel-preset-fbjs": "^3.3.0",
         "metro-babel-transformer": "0.64.0",
         "metro-react-native-babel-preset": "0.64.0",
@@ -54077,7 +54131,6 @@
           "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
           "dev": true,
           "requires": {
-            "@oclif/config": "^1.15.1",
             "@oclif/errors": "^1.3.3",
             "@oclif/parser": "^3.8.3",
             "@oclif/plugin-help": "^3",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,8 @@
     "find-cache-dir": "^3.3.1",
     "find-up": "^5.0.0",
     "fs-extra": "^9.1.0",
+    "image-type": "^4.1.0",
+    "is-svg": "^4.3.1",
     "make-dir": "^3.1.0",
     "mime-types": "^2.1.30",
     "moize": "^6.0.0",


### PR DESCRIPTION
This is a rewrite of the image function. The main fixes are improved error handling and new logic to determine output format. The logic for choosing the output format is as follows:

1. Determine the format of the input image by examining the buffer
2. If the format is SVG or GIF then we do not process it at all, so we redirect to the source image
3. If the format is unsupported (i.e. not JPEG, PNG, WebP or AVIF) then we fall-back to JPEG output
4. If the env var `FORCE_WEBP_OUTPUT` is set, then set output format to WebP. 
5. Otherwise, output format is the same as input format.
Fixes #307 and #312 