### PR TITLE
chore: run CI on latest Node.js

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.13.0, 15.x]
+        node-version: [10.13.0, '*']
         exclude:
           - os: macOS-latest
             node-version: 10.13.0
@@ -26,8 +26,9 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: '*'
       - run: npm ci
       - name: Linting
         run: npm run format:ci
-        if: "${{ matrix.node-version == '15.x' }}"
+        if: "${{ matrix.node-version == '*' }}"
       - run: npm test


### PR DESCRIPTION
Part of https://github.com/netlify/team-dev/issues/19

This runs the CI on the `latest` Node.js version.