### PR TITLE
fix: use allowlist for remote images

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Similarly, you can customize your publish directory in your `netlify.toml` file:
 
 Read more about [Netlify's build settings](https://docs.netlify.com/configure-builds/get-started/#basic-build-settings) in our docs.
 
+## Image handling
+
+The plugin includes a function to generate images for `next/image`. The images are resized on the fly, so the first request will have a short delay. However because the function uses [On-Demand Builders](https://docs.netlify.com/configure-builds/on-demand-builders/), any subsequent requests for that image are served from the edge cache and are super-fast.
+
+By default, images are returned in the same format as the source image if they are in JPEG, PNG, WebP or AVIF format. If you are only targeting modern browsers and want to live life on the edge, you can [set the environment variable](https://docs.netlify.com/configure-builds/environment-variables/) `FORCE_WEBP_OUTPUT` to `"true"`, and it will return all images in WebP format. This will often lead to significant improvements in file size. However you should not use this if you need to support older browsers, as `next/image` does not support picture tag source fallback and images will appear broken. Check [browser support](https://caniuse.com/webp) to see if you are happy to do this.
+
+If you want to use remote images in `next/image`, you will need to add the image domains to an allow list. Setting them in `images.domains` in `next.config.js` is not supported: instead you should set the environment variable `NEXT_IMAGE_ALLOWED_DOMAINS` to a comma-separated list of domains, e.g. `NEXT_IMAGE_ALLOWED_DOMAINS="placekitten.com,unsplash.com"`. 
+
 ## Custom Netlify Redirects
 
 You can define custom redirects in a `_redirects` file.

--- a/index.js
+++ b/index.js
@@ -46,6 +46,14 @@ module.exports = {
 
     // Because we memoize nextConfig, we need to do this after the write file
     const nextConfig = await getNextConfig(utils.failBuild)
+
+    if (nextConfig.images.domains.length !== 0 && !process.env.NEXT_IMAGE_ALLOWED_DOMAINS) {
+      console.log(
+        `Image domains set in next.config.js are ignored.\nPlease set the env variable NEXT_IMAGE_ALLOWED_DOMAINS to "${nextConfig.images.domains.join(
+          ',',
+        )}" instead`,
+      )
+    }
     await restoreCache({ cache: utils.cache, distDir: nextConfig.distDir })
   },
   async onBuild({


### PR DESCRIPTION
This PR adds an allowlist for remote images, to prevent the function being used to proxy arbitrary images. The standard way to support this is by setting a value in next.config.js, however we can't do this as we don't have access to this in the function. Instead we use an env variable and warn if the user sets the value in config instead.

This also adds docs for this and for the WebP env var