### PR TITLE
fix: handle image rotation

### DIFF
--- a/src/lib/templates/imageFunction.js
+++ b/src/lib/templates/imageFunction.js
@@ -94,6 +94,7 @@ const handler = async (event) => {
   // The format methods are just to set options: they don't
   // make it return that format.
   const { info, data: imageBuffer } = await sharp(bufferData)
+    .rotate()
     .jpeg({ quality, mozjpeg: true, force: ext === 'jpg' })
     .png({ quality, palette: true, force: ext === 'png' })
     .webp({ quality, force: ext === 'webp' })


### PR DESCRIPTION
Rotates the image automatically, using the exif rotation data (which we then strip from the image along with all metadata)