### PR TITLE
fix: basePath is undefined when a site has no config file

### DIFF
--- a/src/lib/helpers/convertToBasePathRedirects.js
+++ b/src/lib/helpers/convertToBasePathRedirects.js
@@ -3,7 +3,7 @@
 // NOTE: /withoutProps/redirects.js has some of its own contained basePath logic
 
 const getBasePathDefaultRedirects = ({ basePath, nextRedirects }) => {
-  if (basePath === '') return []
+  if (!basePath) return []
   // In a basePath-configured site, all _next assets are fetched with the prepended basePath
   return [
     {
@@ -16,7 +16,7 @@ const getBasePathDefaultRedirects = ({ basePath, nextRedirects }) => {
 }
 
 const convertToBasePathRedirects = ({ basePath, nextRedirects }) => {
-  if (basePath === '') return nextRedirects
+  if (!basePath) return nextRedirects
   const basePathRedirects = getBasePathDefaultRedirects({ basePath, nextRedirects })
   nextRedirects.forEach((r) => {
     if (r.route === '/') {

--- a/src/lib/helpers/formatRedirectTarget.js
+++ b/src/lib/helpers/formatRedirectTarget.js
@@ -2,7 +2,7 @@
 const { DYNAMIC_PARAMETER_REGEX } = require('../constants/regex')
 
 const formatRedirectTarget = ({ basePath, target }) =>
-  basePath !== '' && target.includes(basePath)
+  basePath && basePath !== '' && target.includes(basePath)
     ? target.replace(DYNAMIC_PARAMETER_REGEX, '/:$1').replace('[', '').replace(']', '').replace('...', '')
     : target
 

--- a/src/lib/pages/withoutProps/redirects.js
+++ b/src/lib/pages/withoutProps/redirects.js
@@ -30,7 +30,7 @@ const getRedirects = async () => {
 
     // For sites that use basePath, manually add necessary redirects here specific
     // only to this page type (which excludes static route redirects by default)
-    if (basePath !== '') {
+    if (basePath && basePath !== '') {
       redirects.push({
         route: `${basePath}${route}`,
         target: route,

--- a/src/lib/steps/setupRedirects.js
+++ b/src/lib/steps/setupRedirects.js
@@ -48,7 +48,7 @@ const setupRedirects = async (publishPath) => {
   redirects.push('# Next-on-Netlify Redirects')
 
   const { basePath } = await getNextConfig()
-  if (basePath !== '') {
+  if (basePath && basePath !== '') {
     nextRedirects = convertToBasePathRedirects({ basePath, nextRedirects })
   }
 


### PR DESCRIPTION
Fixes https://github.com/netlify/netlify-plugin-nextjs/issues/382

i had previously thought basePath defaulted to '' from loadConfig no matter what. thanks to some users who reported very quickly, that is not the case! these updated checks should fix the issue