### PR TITLE
fix: add details to copyNextAssets error messaging

### DIFF
--- a/src/lib/steps/copyNextAssets.js
+++ b/src/lib/steps/copyNextAssets.js
@@ -7,12 +7,16 @@ const { logTitle } = require('../helpers/logger')
 
 // Copy the NextJS' static assets from NextJS distDir to Netlify publish folder.
 // These need to be available for NextJS to work.
+
+// Note: If you're using a custom build setup, such as a monorepo, 
+//       you may need to explicitly set distDir in your next.config.js.
+
 const copyNextAssets = async (publishPath) => {
   const nextDistDir = await getNextDistDir()
   const staticAssetsPath = join(nextDistDir, 'static')
   if (!existsSync(staticAssetsPath)) {
     throw new Error(
-      'No static assets found in .next dist (aka no /.next/static). Please check your project configuration. Your next.config.js must be one of `serverless` or `experimental-serverless-trace`. Your build command should include `next build`.',
+      `No static assets found in your distDir (missing /static in ${nextDistDir}). Please check your project configuration. Your next.config.js must be one of \`serverless\` or \`experimental-serverless-trace\`. Your build command should include \`next build\`.`,
     )
   }
   logTitle('💼 Copying static NextJS assets to', publishPath)


### PR DESCRIPTION
I wound up spending an inordinate amount of time trying to debug issues when attempting to deploy with NX while using this plugin.

Having these specific details would have saved me a lot of trouble. Hopefully, this change will help others down the line.

Thanks for all of your work!