### PR TITLE
docs: add links from readme to docs pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,13 @@ Read more about [file-based plugin installation](https://docs.netlify.com/config
 
 ## Docs
 
-You can find more documentation on the Essential Next.js plugin [here](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs).
+- [CLI Usage](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/cli-usage.md)
+- [Custom Netlify Functions](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/custom-functions.md)
+- [Image Handling](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/image-handling.md)
+- [Custom Netlify Redirects](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/custom-redirects.md)
+- [Local Files in Runtime](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/local-files-in-runtime.md)
+- [FAQ](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/faq.md)
+- [Caveats](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/caveats.md)
 
 ## Credits
 


### PR DESCRIPTION
This PR adds links from the README directly to the docs pages, rather than a single link to the dirctory which is not easy to use