### PR TITLE
fix: handle empty publish directory

### DIFF
--- a/helpers/checkNxConfig.js
+++ b/helpers/checkNxConfig.js
@@ -2,7 +2,7 @@ const { existsSync } = require('fs')
 const { EOL } = require('os')
 const path = require('path')
 
-const checkNxConfig = ({ netlifyConfig, nextConfig, failBuild, constants: { PUBLISH_DIR } }) => {
+const checkNxConfig = ({ netlifyConfig, nextConfig, failBuild, constants: { PUBLISH_DIR = 'out' } }) => {
   const errors = []
   if (nextConfig.distDir === '.next') {
     errors.push(
@@ -15,8 +15,9 @@ const checkNxConfig = ({ netlifyConfig, nextConfig, failBuild, constants: { PUBL
       "Please set the 'publish' value in your Netlify build config to a folder inside your app directory. e.g. 'apps/myapp/out'",
     )
   }
+
   // Look for the config file as a sibling of the publish dir
-  const expectedConfigFile = path.resolve(netlifyConfig.build.publish, '..', 'next.config.js')
+  const expectedConfigFile = path.resolve(netlifyConfig.build.publish || PUBLISH_DIR, '..', 'next.config.js')
 
   if (expectedConfigFile !== nextConfig.configFile) {
     const confName = path.relative(process.cwd(), nextConfig.configFile)

--- a/helpers/getNextRoot.js
+++ b/helpers/getNextRoot.js
@@ -7,7 +7,11 @@ const path = require('path')
  */
 const getNextRoot = ({ netlifyConfig }) => {
   let nextRoot = process.cwd()
-  if (!existsSync(path.join(nextRoot, 'next.config.js')) && netlifyConfig.build.publish) {
+  if (
+    !existsSync(path.join(nextRoot, 'next.config.js')) &&
+    netlifyConfig.build.publish &&
+    netlifyConfig.build.publish !== nextRoot
+  ) {
     nextRoot = path.dirname(netlifyConfig.build.publish)
   }
   return nextRoot

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+const { readdirSync } = require('fs')
 const path = require('path')
 
 const makeDir = require('make-dir')
@@ -60,7 +61,7 @@ module.exports = {
   async onBuild({
     netlifyConfig,
     packageJson,
-    constants: { PUBLISH_DIR, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC },
+    constants: { PUBLISH_DIR = DEFAULT_PUBLISH_DIR, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC },
     utils,
   }) {
     const { failBuild } = utils.build
@@ -74,10 +75,9 @@ module.exports = {
     console.log(`** Running Next on Netlify package **`)
 
     await makeDir(PUBLISH_DIR)
-
     await nextOnNetlify({
       functionsDir: path.resolve(FUNCTIONS_SRC),
-      publishDir: netlifyConfig.build.publish,
+      publishDir: netlifyConfig.build.publish || PUBLISH_DIR,
       nextRoot,
     })
   },
@@ -96,3 +96,4 @@ module.exports = {
 
 const DEFAULT_FUNCTIONS_SRC = 'netlify/functions'
 const DEFAULT_FUNCTIONS_DIST = '.netlify/functions/'
+const DEFAULT_PUBLISH_DIR = 'out'

--- a/src/lib/steps/copyNextAssets.js
+++ b/src/lib/steps/copyNextAssets.js
@@ -1,4 +1,4 @@
-const { join } = require('path')
+const { join, resolve } = require('path')
 
 const { copySync, existsSync } = require('fs-extra')
 
@@ -16,7 +16,9 @@ const copyNextAssets = async (publishPath) => {
   const staticAssetsPath = join(nextDistDir, 'static')
   if (!existsSync(staticAssetsPath)) {
     throw new Error(
-      `No static assets found in your distDir (missing /static in ${nextDistDir}). Please check your project configuration. Your next.config.js must be one of \`serverless\` or \`experimental-serverless-trace\`. Your build command should include \`next build\`.`,
+      `No static assets found in your distDir (missing /static in ${resolve(
+        nextDistDir,
+      )}). Please check your project configuration. Your next.config.js must be one of \`serverless\` or \`experimental-serverless-trace\`. Your build command should include \`next build\`.`,
     )
   }
   logTitle('💼 Copying static NextJS assets to', publishPath)


### PR DESCRIPTION
Fixes a bug where if the publish dir was set to an empty string, then the plugin would think that the root of the Next site was a sibling of that, i.e. it was the directory above the repo root. This PR changes a few things. First, it adds specific handling for empty `PUBLISH_DIR` and `netlifyConfig.build.publish` values when running locally, as well as handling for when the publish dir is the site root. Ideally we'd fail if somebody sets the site root as the publish dir, like we do in the Gatsby plugin, but that would be a breaking change, so instead we work around it.

This fixes the issue that broke some sites after 3.5.0 was released.