### PR TITLE
fix: skip plugin if build command is empty

### DIFF
--- a/helpers/doesNotNeedPlugin.js
+++ b/helpers/doesNotNeedPlugin.js
@@ -1,10 +1,19 @@
 // Checks all the cases for which the plugin should do nothing
+const { redBright } = require('chalk')
+
 const doesSiteUseNextOnNetlify = require('./doesSiteUseNextOnNetlify')
 const isStaticExportProject = require('./isStaticExportProject')
 
 const doesNotNeedPlugin = ({ netlifyConfig, packageJson }) => {
   const { build } = netlifyConfig
   const { scripts = {} } = packageJson
+
+  if (!build.command) {
+    console.log(
+      redBright`⚠️  Warning: No build command specified in the site's Netlify config, so plugin will not run. This deploy will fail unless you have already exported the site.  ⚠️`,
+    )
+    return true
+  }
 
   return isStaticExportProject({ build, scripts }) || doesSiteUseNextOnNetlify({ packageJson })
 }

--- a/index.js
+++ b/index.js
@@ -86,7 +86,9 @@ module.exports = {
     if (doesNotNeedPlugin({ netlifyConfig, packageJson, utils })) {
       utils.status.show({
         title: 'Essential Next.js Build Plugin did not run',
-        summary: 'The site either uses static export, or manually runs next-on-netlify',
+        summary: netlifyConfig.build.command
+          ? 'The site either uses static export, or manually runs next-on-netlify'
+          : 'The site config does not specify a build command',
       })
       return
     }

--- a/test/index.js
+++ b/test/index.js
@@ -73,9 +73,20 @@ afterEach(async () => {
 })
 
 const DUMMY_PACKAGE_JSON = { name: 'dummy', version: '1.0.0' }
-const netlifyConfig = { build: {} }
+const netlifyConfig = { build: { command: 'next build' } }
 
 describe('preBuild()', () => {
+  test('do nothing if the app has no build command', async () => {
+    await plugin.onPreBuild({
+      netlifyConfig: { build: { command: '' } },
+      packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { build: 'next build' } },
+      utils,
+      constants: { FUNCTIONS_SRC: 'out_functions' },
+    })
+
+    expect(await pathExists('next.config.js')).toBeFalsy()
+  })
+
   test('do nothing if the app has static html export in npm script', async () => {
     await plugin.onPreBuild({
       netlifyConfig: { build: { command: 'npm run build' } },
@@ -205,7 +216,7 @@ describe('onBuild()', () => {
     await moveNextDist()
     const PUBLISH_DIR = 'publish'
     await plugin.onBuild({
-      netlifyConfig: { build: { publish: path.resolve(PUBLISH_DIR) } },
+      netlifyConfig: { build: { publish: path.resolve(PUBLISH_DIR), command: 'next build' } },
       packageJson: DUMMY_PACKAGE_JSON,
       constants: {
         PUBLISH_DIR,


### PR DESCRIPTION
If the build command is empty then we won't be able to generate anything, so skip running the plugin