### PR TITLE
fix: handle Storybook and other sites that don't build

### DIFF
--- a/helpers/doesNotNeedPlugin.js
+++ b/helpers/doesNotNeedPlugin.js
@@ -1,8 +1,9 @@
 // Checks all the cases for which the plugin should do nothing
-const { redBright } = require('chalk')
+const { redBright, yellowBright } = require('chalk')
 
 const doesSiteUseNextOnNetlify = require('./doesSiteUseNextOnNetlify')
 const isStaticExportProject = require('./isStaticExportProject')
+const usesBuildCommand = require('./usesBuildCommand')
 
 const doesNotNeedPlugin = ({ netlifyConfig, packageJson }) => {
   const { build } = netlifyConfig
@@ -11,6 +12,13 @@ const doesNotNeedPlugin = ({ netlifyConfig, packageJson }) => {
   if (!build.command) {
     console.log(
       redBright`⚠️  Warning: No build command specified in the site's Netlify config, so plugin will not run. This deploy will fail unless you have already exported the site.  ⚠️`,
+    )
+    return true
+  }
+
+  if (usesBuildCommand({ build, scripts, command: 'build-storybook' })) {
+    console.log(
+      yellowBright`Site seems to be building a Storybook rather than the Next.js site, so the Essential Next.js plugin will not run.`,
     )
     return true
   }

--- a/helpers/isStaticExportProject.js
+++ b/helpers/isStaticExportProject.js
@@ -1,19 +1,12 @@
+const usesBuildCommand = require('./usesBuildCommand')
+
 // Takes 1. Netlify config's build details and
 // 2. the project's package.json scripts to determine if
 // the Next.js app uses static HTML export
 const isStaticExportProject = ({ build, scripts }) => {
   const NEXT_EXPORT_COMMAND = 'next export'
 
-  if (!build.command) return false
-
-  const isSetInNetlifyConfig = build.command.includes(NEXT_EXPORT_COMMAND)
-
-  const isSetInNpmScript = Object.keys(scripts).find((script) => {
-    const scriptValue = scripts[script]
-    return build.command.includes(script) && scriptValue.includes(NEXT_EXPORT_COMMAND)
-  })
-
-  const isStaticExport = isSetInNetlifyConfig || isSetInNpmScript
+  const isStaticExport = usesBuildCommand({ build, scripts, command: NEXT_EXPORT_COMMAND })
 
   if (isStaticExport) {
     console.log(

--- a/helpers/usesBuildCommand.js
+++ b/helpers/usesBuildCommand.js
@@ -1,0 +1,15 @@
+// Does the build command include this value, either directly or via an npm script?
+const usesBuildCommand = ({ build, scripts, command }) => {
+  if (!build.command) return false
+
+  if (build.command.includes(command)) {
+    return true
+  }
+
+  return Object.entries(scripts).some(
+    // Search for a npm script that is being called by the build command, and includes the searched-for command
+    ([scriptName, scriptValue]) => build.command.includes(scriptName) && scriptValue.includes(command),
+  )
+}
+
+module.exports = usesBuildCommand

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,5 @@
+/* eslint-disable max-lines */
+/* eslint-disable max-lines-per-function */
 const path = require('path')
 const process = require('process')
 
@@ -156,6 +158,33 @@ describe('preBuild()', () => {
     expect(process.env.NEXT_PRIVATE_TARGET).toBeUndefined()
   })
 
+  test('do nothing if build command includes "build-storybook"', async () => {
+    await plugin.onPreBuild({
+      netlifyConfig,
+      packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { build: 'build-storybook' } },
+      utils,
+    })
+    expect(process.env.NEXT_PRIVATE_TARGET).toBeUndefined()
+  })
+
+  test('do nothing if build command calls a script that includes "build-storybook"', async () => {
+    await plugin.onPreBuild({
+      netlifyConfig: { build: { command: 'npm run storybook' } },
+      packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { storybook: 'build-storybook' } },
+      utils,
+    })
+    expect(process.env.NEXT_PRIVATE_TARGET).toBeUndefined()
+  })
+
+  test('run plugin if app has build-storybook in an unused script', async () => {
+    await plugin.onPreBuild({
+      netlifyConfig,
+      packageJson: { ...DUMMY_PACKAGE_JSON, scripts: { storybook: 'build-storybook' } },
+      utils,
+    })
+    expect(process.env.NEXT_PRIVATE_TARGET).toBe('serverless')
+  })
+
   test('fail build if the app has no package.json', async () => {
     await expect(
       plugin.onPreBuild({
@@ -289,3 +318,6 @@ describe('onPostBuild', () => {
     expect(path.normalize(manifestPath.digests[0])).toBe(path.normalize('build/build-manifest.json'))
   })
 })
+
+/* eslint-enable max-lines */
+/* eslint-enable max-lines-per-function */


### PR DESCRIPTION
Currently if we detect a site as using Next.js and auto-install the plugin then builds will fail with an error message that isn't very intuitive. In a lot of cases these are actual Next.js sites, but the deployed site is building the STorybook rather than the actual site. This is a common enough pattern for it to be worth detecting specifically. This PR detects the `build-storybook` command and skips the plugin. It also adds an explicit check for the Next build directory after the build, and if it's missing it fails the build with links to docs on configuration or removing the plugin.
Fixes #495 