### PR TITLE
fix: disable png palette

### DIFF
--- a/src/lib/templates/imageFunction.js
+++ b/src/lib/templates/imageFunction.js
@@ -122,8 +122,8 @@ const handler = async (event) => {
   // make it return that format.
   const { info, data: imageBuffer } = await sharp(bufferData)
     .rotate()
-    .jpeg({ quality, mozjpeg: true, force: ext === 'jpg' })
-    .png({ quality, palette: true, force: ext === 'png' })
+    .jpeg({ quality, force: ext === 'jpg' })
+    .png({ quality, force: ext === 'png' })
     .webp({ quality, force: ext === 'webp' })
     .avif({ quality, force: ext === 'avif' })
     .resize(width, null, { withoutEnlargement: true })

--- a/src/lib/templates/imageFunction.js
+++ b/src/lib/templates/imageFunction.js
@@ -84,20 +84,6 @@ const handler = async (event) => {
     return { statusCode: 400, body: 'Source does not appear to be an image' }
   }
 
-  const dimensions = imageSize(bufferData)
-
-  if (width > dimensions.width) {
-    // We won't upsize images, and to avoid downloading the same size multiple times,
-    // we redirect to the largest available size
-    const Location = `/nextimg/${url}/${dimensions.width}/${q}`
-    return {
-      statusCode: 302,
-      headers: {
-        Location,
-      },
-    }
-  }
-
   let { ext } = type
 
   // For unsupported formats (gif, svg) we redirect to the original

--- a/src/lib/templates/imageFunction.js
+++ b/src/lib/templates/imageFunction.js
@@ -48,7 +48,7 @@ const handler = async (event) => {
   } else {
     isRemoteImage = true
     // Remote images need to be in the allowlist
-    let allowedDomains = config.images?.domains || []
+    let allowedDomains = config.domains || []
 
     if (process.env.NEXT_IMAGE_ALLOWED_DOMAINS) {
       console.log('Combining `NEXT_IMAGE_ALLOWED_DOMAINS` with any domains found in `next.config.js`')


### PR DESCRIPTION
Disables png and jpeg optimisation temporarily because it's very slow. This means the output images are larger, but it was unacceptably slow to process. We'll address this with the new image function. We also disable the redirect when requesting images larger than the source. Instead we just disable upsizing. Redirecting meant we'd need to request the source image twice, which was expensive.

Fixes #507