### PR TITLE
fix: catch more export cases

### DIFF
--- a/helpers/usesBuildCommand.js
+++ b/helpers/usesBuildCommand.js
@@ -1,4 +1,7 @@
 const parseNpmScript = require('@netlify/parse-npm-script')
+
+const COMMAND_PLACEHOLDER = '___netlifybuildcommand'
+
 // Does the build command include this value, either directly or via an npm script?
 const usesBuildCommand = ({ build, scripts, command }) => {
   if (!build.command) return false
@@ -10,12 +13,23 @@ const usesBuildCommand = ({ build, scripts, command }) => {
   if (!build.command.includes('npm run') && !build.command.includes('yarn')) {
     return false
   }
+
+  // Insert a fake script to represent the build command
+
+  const commands = { ...scripts, [COMMAND_PLACEHOLDER]: build.command }
+
   // This resolves the npm script that is actually being run
   try {
-    const { raw } = parseNpmScript({ scripts }, build.command)
+    const { raw } = parseNpmScript({ scripts: commands }, COMMAND_PLACEHOLDER)
     return raw.some((script) => script.includes(command))
   } catch (error) {
-    console.error('There was an error parsing your build command', error)
+    console.error(
+      'There was an error parsing your build command:',
+      error.message,
+      `\n\nThe build command is "${build.command}" and the available npm scripts are: ${Object.keys(scripts)
+        .map((script) => `"${script}"`)
+        .join(', ')}`,
+    )
   }
 }
 

--- a/test/fixtures/not-static.json
+++ b/test/fixtures/not-static.json
@@ -53,5 +53,12 @@
             "build:types": "tsc",
             "build": "run-p build:types"
         }
+    },
+    {
+        "command": "npm run build && npm run export",
+        "scripts": {
+            "export": "echo export",
+            "build": "next build"
+        }
     }
 ]

--- a/test/fixtures/static.json
+++ b/test/fixtures/static.json
@@ -13,6 +13,19 @@
         }
     },
     {
+        "command": "npm run build && npm run export",
+        "scripts": {
+            "export": "next export",
+            "build": "next build"
+        }
+    },
+    {
+        "command": "npm run build && next export",
+        "scripts": {
+            "build": "next build"
+        }
+    },
+    {
         "command": "npm run build",
         "scripts": {
             "build:export": "next export",


### PR DESCRIPTION
The update to catch more static export scenarios caused a regression that caused some others to be missed. This PR moves the build command into a fake extra npm script, meaning the `parsePackageJson` module can handle the parsing, and catch more cases. 

Fixes #528