### PR TITLE
fix: handle monorepo caching

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,5 +25,8 @@ module.exports = {
     'unicorn/filename-case': 0,
     'unicorn/no-array-push-push': 0,
   },
+  env: {
+    jest: true,
+  },
   overrides: [...overrides],
 }

--- a/helpers/cacheBuild.js
+++ b/helpers/cacheBuild.js
@@ -3,12 +3,10 @@ const path = require('path')
 const DEFAULT_DIST_DIR = '.next'
 
 // Account for possible custom distDir
-const getPath = (distDir, source) => {
-  return path.join(distDir || DEFAULT_DIST_DIR, source)
-}
+const getPath = (nextRoot, distDir, source) => path.join(nextRoot, distDir || DEFAULT_DIST_DIR, source)
 
-const restoreCache = async ({ cache, distDir }) => {
-  const cacheDir = getPath(distDir, 'cache')
+const restoreCache = async ({ cache, distDir, nextRoot }) => {
+  const cacheDir = getPath(nextRoot, distDir, 'cache')
   if (await cache.restore(cacheDir)) {
     console.log('Next.js cache restored.')
   } else {
@@ -16,9 +14,10 @@ const restoreCache = async ({ cache, distDir }) => {
   }
 }
 
-const saveCache = async ({ cache, distDir }) => {
-  const cacheDir = getPath(distDir, 'cache')
-  const buildManifest = getPath(distDir, 'build-manifest.json')
+const saveCache = async ({ cache, distDir, nextRoot }) => {
+  const cacheDir = getPath(nextRoot, distDir, 'cache')
+
+  const buildManifest = getPath(nextRoot, distDir, 'build-manifest.json')
   if (await cache.save(cacheDir, { digests: [buildManifest] })) {
     console.log('Next.js cache saved.')
   } else {

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ You can do this by running: "npm install -g netlify-cli@latest" or "yarn global 
         `The Essential Next.js plugin now supports reading image domains from your Next config, so using NEXT_IMAGE_ALLOWED_DOMAINS is now deprecated. Please set images.domains in next.config.js instead, and remove the NEXT_IMAGE_ALLOWED_DOMAINS variable.`,
       )
     }
-    await restoreCache({ cache: utils.cache, distDir: nextConfig.distDir })
+    await restoreCache({ cache: utils.cache, distDir: nextConfig.distDir, nextRoot })
   },
   async onBuild({
     netlifyConfig,
@@ -119,7 +119,7 @@ See https://ntl.fyi/remove-plugin for instructions.
     const nextRoot = getNextRoot({ netlifyConfig })
 
     const nextConfig = await getNextConfig(utils.failBuild, nextRoot)
-    await saveCache({ cache: utils.cache, distDir: nextConfig.distDir })
+    await saveCache({ cache: utils.cache, distDir: nextConfig.distDir, nextRoot })
     copyUnstableIncludedDirs({ nextConfig, functionsDist: path.resolve(FUNCTIONS_DIST) })
     utils.status.show({
       title: 'Essential Next.js Build Plugin ran successfully',

--- a/test/index.js
+++ b/test/index.js
@@ -235,24 +235,16 @@ describe('preBuild()', () => {
   test('restores cache with right paths', async () => {
     await useFixture('dist_dir_next_config')
 
-    let distPath
-    const utils_ = {
-      ...utils,
-      cache: {
-        restore: (x) => (distPath = x),
-      },
-    }
-    const spy = jest.spyOn(utils_.cache, 'restore')
+    const restore = jest.fn()
 
     await plugin.onPreBuild({
       netlifyConfig,
       packageJson: DUMMY_PACKAGE_JSON,
-      utils: utils_,
+      utils: { ...utils, cache: { restore } },
       constants: { FUNCTIONS_SRC: 'out_functions' },
     })
 
-    expect(spy).toHaveBeenCalled()
-    expect(path.normalize(distPath)).toBe(path.normalize('build/cache'))
+    expect(restore).toHaveBeenCalledWith(path.resolve('build/cache'))
   })
 })
 
@@ -316,29 +308,18 @@ describe('onPostBuild', () => {
   test('saves cache with right paths', async () => {
     await useFixture('dist_dir_next_config')
 
-    let distPath
-    let manifestPath
-    const utils_ = {
-      ...utils,
-      cache: {
-        save: (x, y) => {
-          distPath = x
-          manifestPath = y
-        },
-      },
-    }
-    const spy = jest.spyOn(utils_.cache, 'save')
+    const save = jest.fn()
 
     await plugin.onPostBuild({
       netlifyConfig,
       packageJson: DUMMY_PACKAGE_JSON,
-      utils: utils_,
+      utils: { ...utils, cache: { save } },
       constants: { FUNCTIONS_SRC: 'out_functions' },
     })
 
-    expect(spy).toHaveBeenCalled()
-    expect(path.normalize(distPath)).toBe(path.normalize('build/cache'))
-    expect(path.normalize(manifestPath.digests[0])).toBe(path.normalize('build/build-manifest.json'))
+    expect(save).toHaveBeenCalledWith(path.resolve('build/cache'), {
+      digests: [path.resolve('build/build-manifest.json')],
+    })
   })
 })
 


### PR DESCRIPTION
When caching a build, the distDir wasn't being found in monorepos, because it wasn't accounting for `nextRoot`. This PR ensures that nextRoot is used.

Fixes #500