### PR TITLE
chore: don't use esbuild by default

### DIFF
--- a/src/lib/helpers/setupNetlifyFunctionForPage.js
+++ b/src/lib/helpers/setupNetlifyFunctionForPage.js
@@ -23,7 +23,7 @@ const setupNetlifyFunctionForPage = async ({ filePath, functionsPath, isApiPage,
   }
 
   // Write entry point to function directory
-  const entryPointPath = join(functionDirectory, `${functionName}.ts`)
+  const entryPointPath = join(functionDirectory, `${functionName}.js`)
   await writeFile(entryPointPath, getTemplate({ filePath, isISR }))
 
   // Copy function helper

--- a/src/lib/templates/getTemplate.js
+++ b/src/lib/templates/getTemplate.js
@@ -1,14 +1,14 @@
 const getTemplate = ({ filePath, isISR }) => {
   if (isISR) {
     return `// Auto-generated file. DO NOT MODIFY.
-import { getHandlerFunction } from './getHandlerFunction'
-import { builder } from '@netlify/functions'
-export const handler = builder(getHandlerFunction(require("./nextPage/${filePath}")))
+const { getHandlerFunction } = require('./getHandlerFunction')
+const { builder } = require('@netlify/functions')
+exports.handler = builder(getHandlerFunction(require("./nextPage/${filePath}")))
 `
   }
   return `// Auto-generated file. DO NOT MODIFY.
-import { getHandlerFunction } from './getHandlerFunction'
-export const handler = getHandlerFunction(require("./nextPage/${filePath}"))
+const { getHandlerFunction } = require('./getHandlerFunction')
+exports.handler = getHandlerFunction(require("./nextPage/${filePath}"))
   `
 }
 

--- a/src/tests/configurableDirs.test.js
+++ b/src/tests/configurableDirs.test.js
@@ -45,13 +45,13 @@ describe('next-on-netlify', () => {
   })
 
   test('creates a Netlify Function for each SSR page', () => {
-    expect(existsSync(join(functionsDir, 'next_index', 'next_index.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_shows_id', 'next_shows_id.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_shows_params', 'next_shows_params.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_getServerSideProps_static', 'next_getServerSideProps_static.ts'))).toBe(
+    expect(existsSync(join(functionsDir, 'next_index', 'next_index.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_shows_id', 'next_shows_id.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_shows_params', 'next_shows_params.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_getServerSideProps_static', 'next_getServerSideProps_static.js'))).toBe(
       true,
     )
-    expect(existsSync(join(functionsDir, 'next_getServerSideProps_id', 'next_getServerSideProps_id.ts'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_getServerSideProps_id', 'next_getServerSideProps_id.js'))).toBe(true)
   })
 
   test('copies static pages to output directory', () => {

--- a/src/tests/defaults.test.js
+++ b/src/tests/defaults.test.js
@@ -61,14 +61,14 @@ describe('SSR Pages', () => {
   const functionsDir = join(PROJECT_PATH, 'out_functions')
 
   test('creates a Netlify Function for each SSR page', () => {
-    expect(existsSync(join(functionsDir, 'next_index', 'next_index.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_shows_id', 'next_shows_id.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_shows_params', 'next_shows_params.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_getServerSideProps_static', 'next_getServerSideProps_static.ts'))).toBe(
+    expect(existsSync(join(functionsDir, 'next_index', 'next_index.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_shows_id', 'next_shows_id.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_shows_params', 'next_shows_params.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_getServerSideProps_static', 'next_getServerSideProps_static.js'))).toBe(
       true,
     )
     expect(
-      readFileSync(join(functionsDir, 'next_getServerSideProps_id', 'next_getServerSideProps_id.ts'), 'utf-8'),
+      readFileSync(join(functionsDir, 'next_getServerSideProps_id', 'next_getServerSideProps_id.js'), 'utf-8'),
     ).toMatch(`require("./nextPage/pages/getServerSideProps/[id].js")`)
   })
 })
@@ -77,10 +77,10 @@ describe('API Pages', () => {
   const functionsDir = join(PROJECT_PATH, 'out_functions')
 
   test('creates a Netlify Function for each API endpoint', () => {
-    expect(existsSync(join(functionsDir, 'next_api_static', 'next_api_static.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_api_shows_id', 'next_api_shows_id.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_api_shows_params', 'next_api_shows_params.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_api_hello-background', 'next_api_hello-background.ts'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_static', 'next_api_static.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_shows_id', 'next_api_shows_id.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_shows_params', 'next_api_shows_params.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_hello-background', 'next_api_hello-background.js'))).toBe(true)
   })
 })
 
@@ -126,10 +126,10 @@ describe('SSG Pages with getStaticProps', () => {
   })
 
   test('creates Netlify Functions for pages with fallback', () => {
-    const functionPath1 = 'next_getStaticProps_withFallback_id/next_getStaticProps_withFallback_id.ts'
+    const functionPath1 = 'next_getStaticProps_withFallback_id/next_getStaticProps_withFallback_id.js'
     expect(existsSync(join(PROJECT_PATH, 'out_functions', functionPath1))).toBe(true)
 
-    const functionPath2 = 'next_getStaticProps_withFallback_slug/next_getStaticProps_withFallback_slug.ts'
+    const functionPath2 = 'next_getStaticProps_withFallback_slug/next_getStaticProps_withFallback_slug.js'
     expect(existsSync(join(PROJECT_PATH, 'out_functions', functionPath2))).toBe(true)
   })
 })
@@ -139,11 +139,11 @@ describe('SSG Pages with getStaticProps and revalidate', () => {
 
   test('creates a Netlify Function for each page', () => {
     expect(
-      existsSync(join(functionsDir, 'next_getStaticProps_withrevalidate', 'next_getStaticProps_withrevalidate.ts')),
+      existsSync(join(functionsDir, 'next_getStaticProps_withrevalidate', 'next_getStaticProps_withrevalidate.js')),
     ).toBe(true)
     expect(
       existsSync(
-        join(functionsDir, 'next_getStaticProps_withRevalidate_id', 'next_getStaticProps_withRevalidate_id.ts'),
+        join(functionsDir, 'next_getStaticProps_withRevalidate_id', 'next_getStaticProps_withRevalidate_id.js'),
       ),
     ).toBe(true)
     expect(
@@ -151,7 +151,7 @@ describe('SSG Pages with getStaticProps and revalidate', () => {
         join(
           functionsDir,
           'next_getStaticProps_withRevalidate_withFallback_id',
-          'next_getStaticProps_withRevalidate_withFallback_id.ts',
+          'next_getStaticProps_withRevalidate_withFallback_id.js',
         ),
       ),
     ).toBe(true)

--- a/src/tests/i18n.test.js
+++ b/src/tests/i18n.test.js
@@ -61,13 +61,13 @@ describe('SSR Pages', () => {
   const functionsDir = join(PROJECT_PATH, 'out_functions')
 
   test('creates a Netlify Function for each SSR page', () => {
-    expect(existsSync(join(functionsDir, 'next_index', 'next_index.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_shows_id', 'next_shows_id.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_shows_params', 'next_shows_params.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_getServerSideProps_static', 'next_getServerSideProps_static.ts'))).toBe(
+    expect(existsSync(join(functionsDir, 'next_index', 'next_index.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_shows_id', 'next_shows_id.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_shows_params', 'next_shows_params.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_getServerSideProps_static', 'next_getServerSideProps_static.js'))).toBe(
       true,
     )
-    expect(existsSync(join(functionsDir, 'next_getServerSideProps_id', 'next_getServerSideProps_id.ts'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_getServerSideProps_id', 'next_getServerSideProps_id.js'))).toBe(true)
   })
 })
 
@@ -75,9 +75,9 @@ describe('API Pages', () => {
   const functionsDir = join(PROJECT_PATH, 'out_functions')
 
   test('creates a Netlify Function for each API endpoint', () => {
-    expect(existsSync(join(functionsDir, 'next_api_static', 'next_api_static.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_api_shows_id', 'next_api_shows_id.ts'))).toBe(true)
-    expect(existsSync(join(functionsDir, 'next_api_shows_params', 'next_api_shows_params.ts'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_static', 'next_api_static.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_shows_id', 'next_api_shows_id.js'))).toBe(true)
+    expect(existsSync(join(functionsDir, 'next_api_shows_params', 'next_api_shows_params.js'))).toBe(true)
   })
 })
 
@@ -110,10 +110,10 @@ describe('SSG Pages with getStaticProps', () => {
   })
 
   test('creates Netlify Functions for pages with fallback', () => {
-    const functionPath1 = 'next_getStaticProps_withFallback_id/next_getStaticProps_withFallback_id.ts'
+    const functionPath1 = 'next_getStaticProps_withFallback_id/next_getStaticProps_withFallback_id.js'
     expect(existsSync(join(PROJECT_PATH, 'out_functions', functionPath1))).toBe(true)
 
-    const functionPath2 = 'next_getStaticProps_withFallback_slug/next_getStaticProps_withFallback_slug.ts'
+    const functionPath2 = 'next_getStaticProps_withFallback_slug/next_getStaticProps_withFallback_slug.js'
     expect(existsSync(join(PROJECT_PATH, 'out_functions', functionPath2))).toBe(true)
   })
 })
@@ -123,11 +123,11 @@ describe('SSG Pages with getStaticProps and revalidate', () => {
 
   test('creates a Netlify Function for each page', () => {
     expect(
-      existsSync(join(functionsDir, 'next_getStaticProps_withrevalidate', 'next_getStaticProps_withrevalidate.ts')),
+      existsSync(join(functionsDir, 'next_getStaticProps_withrevalidate', 'next_getStaticProps_withrevalidate.js')),
     ).toBe(true)
     expect(
       existsSync(
-        join(functionsDir, 'next_getStaticProps_withRevalidate_id', 'next_getStaticProps_withRevalidate_id.ts'),
+        join(functionsDir, 'next_getStaticProps_withRevalidate_id', 'next_getStaticProps_withRevalidate_id.js'),
       ),
     ).toBe(true)
     expect(
@@ -135,7 +135,7 @@ describe('SSG Pages with getStaticProps and revalidate', () => {
         join(
           functionsDir,
           'next_getStaticProps_withRevalidate_withFallback_id',
-          'next_getStaticProps_withRevalidate_withFallback_id.ts',
+          'next_getStaticProps_withRevalidate_withFallback_id.js',
         ),
       ),
     ).toBe(true)

--- a/test/index.js
+++ b/test/index.js
@@ -336,7 +336,7 @@ describe('onBuild()', () => {
       utils,
     })
 
-    expect(await pathExists(`${resolvedFunctions}/next_api_test/next_api_test.ts`)).toBeTruthy()
+    expect(await pathExists(`${resolvedFunctions}/next_api_test/next_api_test.js`)).toBeTruthy()
   })
 })
 


### PR DESCRIPTION
This PR switches the function entrypoints back to js from ts, so it no lonegr forces esbuild. Users can still specify esbuild and get the performance gains, but we won't force them until we're able to do staged rollouts of plugin versions.