### PR TITLE
fix: exit on unhandled promise rejection in build

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,10 @@ You can do this by running: "npm install -g netlify-cli@latest" or "yarn global 
       )
     }
     await restoreCache({ cache: utils.cache, distDir: nextConfig.distDir, nextRoot })
+
+    // Exit the build process on unhandled promise rejection. This is the default in Node 15+, but earlier versions just warn.
+    // This causes problems as it doesn't then know the build has failed until we try to copy the assets.
+    process.env.NODE_OPTIONS = [process.env.NODE_OPTIONS, '--unhandled-rejections=strict'].filter(Boolean).join(' ')
   },
   async onBuild({
     netlifyConfig,


### PR DESCRIPTION
The default behavior in versions of Node < 15 is to just warn when a promise rejection is unhandled. This means that often we can't tell if the build has failed until we try to copy the built artifacts. This PR adds `--unhandled-rejections=strict` to `NODE_OPTIONS`, meaning that unhandled rejections fail the build early. This should not be a breaking change, because these builds already fail but it's just later and incorrectly appears to be a plugin error rather than a build error.