### PR TITLE
feat: try to generate stable build ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,9 @@ Temporary Items
 .apdisk
 
 # End of https://www.toptal.com/developers/gitignore/api/osx,node
+
 demo/package-lock.json
+# We generate this on build in the demo
+demo/next.config.js
 
 .netlify

--- a/demo/next.config.js
+++ b/demo/next.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  // Supported targets are "serverless" and "experimental-serverless-trace"
-  target: "serverless"
-}

--- a/helpers/verifyBuildTarget.js
+++ b/helpers/verifyBuildTarget.js
@@ -12,7 +12,18 @@ const verifyBuildTarget = async ({ failBuild, netlifyConfig }) => {
 
   const { target, configFile } = await getNextConfig(failBuild, nextRoot)
 
-  // If the next config exists, log warning if target isnt in acceptableTargets
+  if (!configFile) {
+    await writeFile(
+      path.resolve(nextRoot, 'next.config.js'),
+      `module.exports = {
+  // Supported targets are "serverless" and "experimental-serverless-trace"
+  target: "serverless",
+  generateBuildId: () => "build"
+}`,
+    )
+  }
+
+  // If the next config exists, log warning if target isn't in acceptableTargets
   const acceptableTargets = ['serverless', 'experimental-serverless-trace']
   const isValidTarget = acceptableTargets.includes(target)
   if (isValidTarget) {
@@ -49,18 +60,6 @@ const verifyBuildTarget = async ({ failBuild, netlifyConfig }) => {
   // Clear memoized cache
   getNextConfig.clear()
 
-  // Creating a config file, because otherwise Next won't reload the config and pick up the new target
-
-  if (!configFile) {
-    await writeFile(
-      path.resolve(nextRoot, 'next.config.js'),
-      `
-module.exports = {
-  // Supported targets are "serverless" and "experimental-serverless-trace"
-  target: "serverless"
-}`,
-    )
-  }
   // Force the new config to be generated
   await getNextConfig(failBuild, nextRoot)
   // Reset the value in case something else is looking for it

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const { readdirSync, existsSync } = require('fs')
 const path = require('path')
 
-const { yellowBright, greenBright } = require('chalk')
+const { yellowBright, greenBright, green } = require('chalk')
 const makeDir = require('make-dir')
 const { satisfies } = require('semver')
 const glob = require('tiny-glob')
@@ -140,12 +140,24 @@ See https://ntl.fyi/remove-plugin for instructions.
     const nextRoot = getNextRoot({ netlifyConfig })
 
     const nextConfig = await getNextConfig(utils.failBuild, nextRoot)
-    await saveCache({ cache: utils.cache, distDir: nextConfig.distDir, nextRoot })
+    const { distDir, generateBuildId } = nextConfig
+    await saveCache({ cache: utils.cache, distDir, nextRoot })
     copyUnstableIncludedDirs({ nextConfig, functionsDist: path.resolve(FUNCTIONS_DIST) })
     utils.status.show({
       title: 'Essential Next.js Build Plugin ran successfully',
       summary: 'Generated serverless functions and stored the Next.js cache',
     })
+
+    // The default generateBuildId function returns null, which causes it to use a random value from nanoid
+    // eslint-disable-next-line no-self-compare
+    if (generateBuildId() === null || generateBuildId() !== generateBuildId()) {
+      console.warn(
+        yellowBright`
+For faster deploy times, build IDs should be set to a static value.
+To do this, set ${green`generateBuildId: () => 'build'`} in your next.config.js`,
+        // TODO: add shortlink when docs are updated
+      )
+    }
   },
 }
 


### PR DESCRIPTION
By default Next.js generates random build IDs. This means that every build will generate changed files, which means they need to be deployed every time. This PR changes the generated `next.config.js` to use a static build ID, and adds an `onPostBuild` check that logs a warning if it's using random IDs.

Fixes  #604