### PR TITLE
chore: update node version in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,12 +12,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.13.0, '*']
+        node-version: [12, '*']
         exclude:
           - os: macOS-latest
-            node-version: 10.13.0
+            node-version: 12
           - os: windows-latest
-            node-version: 10.13.0
+            node-version: 12
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Because Next.js has dropped support for Node 10, we can drop it from tests too. Instead, I've added tests on Node 12, which is the current minimum version