### PR TITLE
fix: links to docs are pointing to wrong branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ Read more about [file-based plugin installation](https://docs.netlify.com/config
 
 ## Docs
 
-- [CLI Usage](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/cli-usage.md)
-- [Custom Netlify Functions](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/custom-functions.md)
-- [Image Handling](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/image-handling.md)
-- [Monorepos and Nx](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/monorepos.md)
-- [Custom Netlify Redirects](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/custom-redirects.md)
-- [Local Files in Runtime](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/local-files-in-runtime.md)
-- [FAQ](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/faq.md)
-- [Caveats](https://github.com/netlify/netlify-plugin-nextjs/tree/main/docs/caveats.md)
+- [CLI Usage](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/cli-usage.md)
+- [Custom Netlify Functions](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/custom-functions.md)
+- [Image Handling](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/image-handling.md)
+- [Monorepos and Nx](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/monorepos.md)
+- [Custom Netlify Redirects](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/custom-redirects.md)
+- [Local Files in Runtime](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/local-files-in-runtime.md)
+- [FAQ](https://github.com/netlify/netlify-plugin-nextjs/tree/v3/docs/faq.md)
+- [Caveats](https://github.com/netlify/netlify-plugin-nextjs/tree/main/v3/caveats.md)
 
 ## Credits
 


### PR DESCRIPTION
All of the `Docs` links are pointing to the wrong branch.

<!--Please tag yourself as the Assignee and at least one specific Ecosystem engineer as the Reviewer (@ascorbic, @lindsaylevine, @tiffanosaurus) -->

### Summary
<!-- Provide a summary brief summary of the change. -->

### Screenshots changes if applicable
<!-- Please delete this section if not applicable to this PR. -->

**Before:**

**After:**

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]())
   ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal (small picture)

### Standard checks:
<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary
---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
