### PR TITLE
fix: ensure path is encoded

### DIFF
--- a/src/templates/getHandler.js
+++ b/src/templates/getHandler.js
@@ -109,6 +109,8 @@ const makeHandler =
     bridge.listen()
 
     return async (event, context) => {
+      // Ensure that paths are encoded - but don't double-encode them
+      event.path = new URL(event.path, event.rawUrl).pathname
       // Next expects to be able to parse the query from the URL
       const query = new URLSearchParams(event.queryStringParameters).toString()
       event.path = query ? `${event.path}?${query}` : event.path


### PR DESCRIPTION
### Summary
Ensure paths are URL-encoded. Uses the `URL` constructor, because it avoids double-encoding if the path is already encoded.

### Test plan

1. Visit the Deploy Preview, with a path that included a space or special character. Site should give a custom 404, rather than a 502 error

- [Main branch](https://netlify-plugin-nextjs-demo.netlify.app/hello%20world) 
- [This PR](https://deploy-preview-800--netlify-plugin-nextjs-demo.netlify.app/hello%20world)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal (small picture)
Closes #786


### Standard checks:
<!-- Please delete any options that reviewers shouldn't check. -->

- [x] Check the Deploy Preview's Demo site for your PR's functionality

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
