### PR TITLE
feat: move static pages by default

### DIFF
--- a/docs/large-functions.md
+++ b/docs/large-functions.md
@@ -1,19 +1,26 @@
 ## Troubleshooting large functions
 
-You may see an error about generated functions being too large. This is because when deploying your site it is packaged into a zipfile, which is limited by AWS to 50MB in size. 
-There are two possible causes for this, each with its own solution. The list of largest files shown in the build logs will help you see what the cause is.
+You may see an error about generated functions being too large. This is because when deploying your site it is packaged
+into a zipfile, which is limited by AWS to 50MB in size. There are two possible causes for this, each with its own
+solution. The list of largest files shown in the build logs will help you see what the cause is.
 
-- **Large dependencies**
-    This is the most common cause of the problem. Some node modules are very large, mostly those that include native modules. Examples include `electron` and `chromium`. The function bundler is usually able to find out which modules are actually used by your code, but sometimes it will incorrectly include unneeded modules. If this is the case, you can either remove the module from your dependencies if you installed it yourself, or exclude it manually by adding something like this to your `netlify.toml`, changing the value according to the problematic module. The `!` at the beginning of the module path indicates that it should be excluded:
+- **Large dependencies** This is the most common cause of the problem. Some node modules are very large, mostly those
+  that include native modules. Examples include `electron` and `chromium`. The function bundler is usually able to find
+  out which modules are actually used by your code, but sometimes it will incorrectly include unneeded modules. If this
+  is the case, you can either remove the module from your dependencies if you installed it yourself, or exclude it
+  manually by adding something like this to your `netlify.toml`, changing the value according to the problematic module.
+  The `!` at the beginning of the module path indicates that it should be excluded:
 
-    ```toml
-    [functions]
-    included_files = ["!node_modules/a-large-module/**/*"]
-    ```
+  ```toml
+  [functions]
+  included_files = ["!node_modules/a-large-module/**/*"]
+  ```
 
-    If you do need large modules at runtime (e.g. if you are running Puppeteer in a Next API route), consider changing to a Netlify function which will have less overhead than the equivalent Next.js function.
+  If you do need large modules at runtime (e.g. if you are running Puppeteer in a Next API route), consider changing to
+  a Netlify function which will have less overhead than the equivalent Next.js function.
 
-- **Large numbers of pre-rendered pages**
-  If you have a very large number of pre-rendered pages, these can take up a lot of space in the function. There are two approaches to fixing this. One is to consider deferring the building of the pages. If you return `fallback: "blocking"` from `getStaticPaths` the rendering will be deferred until the first user requests the page. This is a good choice for low-traffic pages. It reduces build and deploy time, and can make your bundle a lot smaller. 
-  
-  The other option is to enable an experimental feature that moves static files out of the function bundle. To do this, set the environment variable `EXPERIMENTAL_MOVE_STATIC_PAGES` to true.
+- **Large numbers of pre-rendered pages** If you have a very large number of pre-rendered pages, these can take up a lot
+  of space in the function. There are two approaches to fixing this. One is to consider deferring the building of the
+  pages. If you return `fallback: "blocking"` from `getStaticPaths` the rendering will be deferred until the first user
+  requests the page. This is a good choice for low-traffic pages. It reduces build and deploy time, and can make your
+  bundle a lot smaller.

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -44,28 +44,11 @@ export async function middleware(req: NextRequest) {
 
 Because the middleware runs at the origin, it is run _after_ Netlify rewrites and redirects. If a static file is served
 by the Netlify CDN then the middleware is never run, as middleware only runs when a page is served by Next.js. This
-means that middleware should not be used with the `EXPERIMENTAL_MOVE_STATIC_FILES` option, as this causes
-statically-generated pages to be served by the Netlify CDN before any middleware can be run.
+means that any pages that match middleware routes are served from the origin rather than the CDN.
 
 There is a bug in Next.js `<=12.0.3` that causes a proxy loop if you try to rewrite to a URL with a host other than
-localhost. This bug is fixed in version `12.0.4`. If you are using Next.js `<=12.0.3`, you can work around the bug by
-ensuring that when rewriting a request you either use a relative path, or manually set the host to `localhost` if
-returning a URL object. For example:
-
-```typescript
-export function middleware(req: NextRequest) {
-  const rewrittenUrl = req.nextUrl
-
-  // Change the URL in some way
-  // ...
-
-  // Before returning the URL, set the host to localhost
-  rewrittenUrl.host = 'localhost'
-
-  // ...then rewrite to the changed URL
-  return NextResponse.rewrite(rewrittenUrl)
-}
-```
+localhost. This bug is fixed in version `12.0.4`, so if you are using middleware you should upgrade to that version or
+later.
 
 If you have an issue with Next.js middleware on Netlify while it is beta, particularly if the issue cannot be reproduced
 when running locally, then please add a comment to

--- a/src/index.js
+++ b/src/index.js
@@ -57,6 +57,12 @@ module.exports = {
     await movePublicFiles({ appDir, publish })
 
     if (process.env.EXPERIMENTAL_MOVE_STATIC_PAGES) {
+      console.log(
+        "The flag 'EXPERIMENTAL_MOVE_STATIC_PAGES' is no longer required, as it is now the default. To disable this behavior, set the env var 'SERVE_STATIC_FILES_FROM_ORIGIN' to 'true'",
+      )
+    }
+
+    if (!process.env.SERVE_STATIC_FILES_FROM_ORIGIN) {
       await moveStaticPages({ target, failBuild, netlifyConfig, i18n })
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -207,18 +207,15 @@ describe('onBuild()', () => {
 
   test('generates static files manifest', async () => {
     await moveNextDist()
-    process.env.EXPERIMENTAL_MOVE_STATIC_PAGES = 'true'
     await plugin.onBuild(defaultArgs)
     const manifestPath = path.resolve('.next/static-manifest.json')
     expect(existsSync(manifestPath)).toBeTruthy()
     const data = (await readJson(manifestPath)).sort()
     expect(data).toMatchSnapshot()
-    delete process.env.EXPERIMENTAL_MOVE_STATIC_PAGES
   })
 
   test('moves static files to root', async () => {
     await moveNextDist()
-    process.env.EXPERIMENTAL_MOVE_STATIC_PAGES = 'true'
     await plugin.onBuild(defaultArgs)
     const data = JSON.parse(readFileSync(path.resolve('.next/static-manifest.json'), 'utf8'))
 
@@ -226,13 +223,10 @@ describe('onBuild()', () => {
       expect(existsSync(path.resolve(path.join('.next', file)))).toBeTruthy()
       expect(existsSync(path.resolve(path.join('.next', 'server', 'pages', file)))).toBeFalsy()
     })
-
-    delete process.env.EXPERIMENTAL_MOVE_STATIC_PAGES
   })
 
   test('copies default locale files to top level', async () => {
     await moveNextDist()
-    process.env.EXPERIMENTAL_MOVE_STATIC_PAGES = 'true'
     await plugin.onBuild(defaultArgs)
     const data = JSON.parse(readFileSync(path.resolve('.next/static-manifest.json'), 'utf8'))
 
@@ -245,19 +239,14 @@ describe('onBuild()', () => {
       const trimmed = file.substring(locale.length)
       expect(existsSync(path.resolve(path.join('.next', trimmed)))).toBeTruthy()
     })
-
-    delete process.env.EXPERIMENTAL_MOVE_STATIC_PAGES
   })
 
   test('skips static files that match middleware', async () => {
     await moveNextDist()
-    process.env.EXPERIMENTAL_MOVE_STATIC_PAGES = 'true'
     await plugin.onBuild(defaultArgs)
 
     expect(existsSync(path.resolve(path.join('.next', 'en', 'middle.html')))).toBeFalsy()
     expect(existsSync(path.resolve(path.join('.next', 'server', 'pages', 'en', 'middle.html')))).toBeTruthy()
-
-    delete process.env.EXPERIMENTAL_MOVE_STATIC_PAGES
   })
 
   test('sets correct config', async () => {


### PR DESCRIPTION
### Summary

This PR changes the `EXPERIMENTAL_MOVE_STATIC_FILES` mode to be the default, so any statically-rendered pages are served from the CDN rather than the origin, unless they match middleware. It adds a new env var `SERVE_STATIC_FILES_FROM_ORIGIN` to disable the mode.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://user-images.githubusercontent.com/213306/142638426-5a475f59-5f4b-4305-853e-09ef0488fbd1.png)

