### PR TITLE
fix: don't move files to the CDN if they match redirect/rewrite rules

### DIFF
--- a/demo/next.config.js
+++ b/demo/next.config.js
@@ -4,7 +4,7 @@ module.exports = {
   generateBuildId: () => 'build-id',
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'es', 'fr']
+    locales: ['en', 'es', 'fr'],
   },
   async headers() {
     return [
@@ -14,7 +14,7 @@ module.exports = {
           {
             key: 'x-custom-header',
             value: 'my custom header value',
-          }
+          },
         ],
       },
     ]
@@ -29,8 +29,8 @@ module.exports = {
         {
           source: '/old/:path*',
           destination: '/:path*',
-        }
-      ]
+        },
+      ],
     }
   },
   // Redirects allow you to redirect an incoming request path to a different destination path.

--- a/demo/pages/old/image.js
+++ b/demo/pages/old/image.js
@@ -1,0 +1,7 @@
+const Images = () => (
+  <div>
+    <p>If you can see this, rewrites aren&apos;t working</p>
+  </div>
+)
+
+export default Images

--- a/demo/pages/redirectme.js
+++ b/demo/pages/redirectme.js
@@ -1,0 +1,7 @@
+const Redirect = () => (
+  <div>
+    <p>If you can see this, redirects aren&apos;t working</p>
+  </div>
+)
+
+export default Redirect

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -42,6 +42,9 @@ const matchesRedirect = (file, redirects) => {
 }
 
 const matchesRewrite = (file, rewrites) => {
+  if (Array.isArray(rewrites)) {
+    return matchesRedirect(file, rewrites)
+  }
   if (!Array.isArray(rewrites?.beforeFiles)) {
     return false
   }

--- a/src/helpers/files.js
+++ b/src/helpers/files.js
@@ -1,4 +1,4 @@
-//  @ts-check
+/* eslint-disable max-lines */
 const { cpus } = require('os')
 
 const { yellowBright } = require('chalk')
@@ -28,10 +28,33 @@ const matchMiddleware = (middleware, filePath) =>
       filePath === middlewarePath || filePath === `${middlewarePath}.html` || filePath.startsWith(`${middlewarePath}/`),
   )
 
+const matchesRedirect = (file, redirects) => {
+  if (!Array.isArray(redirects)) {
+    return false
+  }
+  return redirects.some((redirect) => {
+    if (!redirect.regex || redirect.internal) {
+      return false
+    }
+    // Strips the extension from the file path
+    return new RegExp(redirect.regex).test(`/${file.slice(0, -5)}`)
+  })
+}
+
+const matchesRewrite = (file, rewrites) => {
+  if (!Array.isArray(rewrites?.beforeFiles)) {
+    return false
+  }
+  return matchesRedirect(file, rewrites.beforeFiles)
+}
+
+exports.matchesRedirect = matchesRedirect
+exports.matchesRewrite = matchesRewrite
 exports.matchMiddleware = matchMiddleware
 exports.stripLocale = stripLocale
 exports.isDynamicRoute = isDynamicRoute
 
+// eslint-disable-next-line max-lines-per-function
 exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
   console.log('Moving static page files to serve from CDN...')
   const outputDir = join(netlifyConfig.build.publish, target === 'server' ? 'server' : 'serverless')
@@ -48,6 +71,7 @@ exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
   }
 
   const prerenderManifest = await readJson(join(netlifyConfig.build.publish, 'prerender-manifest.json'))
+  const { redirects, rewrites } = await readJson(join(netlifyConfig.build.publish, 'routes-manifest.json'))
 
   const isrFiles = new Set()
 
@@ -79,6 +103,8 @@ exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
 
   const matchingMiddleware = new Set()
   const matchedPages = new Set()
+  const matchedRedirects = new Set()
+  const matchedRewrites = new Set()
 
   // Limit concurrent file moves to number of cpus or 2 if there is only 1
   const limit = pLimit(Math.max(2, cpus().length))
@@ -89,6 +115,14 @@ exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
       return
     }
     if (isDynamicRoute(filePath)) {
+      return
+    }
+    if (matchesRedirect(filePath, redirects)) {
+      matchedRedirects.add(filePath)
+      return
+    }
+    if (matchesRewrite(filePath, rewrites)) {
+      matchedRewrites.add(filePath)
       return
     }
     // Middleware matches against the unlocalised path
@@ -110,7 +144,8 @@ exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
       yellowBright(outdent`
         Skipped moving ${matchedPages.size} ${
         matchedPages.size === 1 ? 'file because it matches' : 'files because they match'
-      } middleware, so cannot be deployed to the CDN and will be served from the origin instead. This is fine, but we're letting you know because it may not be what you expect.
+      } middleware, so cannot be deployed to the CDN and will be served from the origin instead. 
+        This is fine, but we're letting you know because it may not be what you expect.
       `),
     )
 
@@ -119,6 +154,8 @@ exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
         The following middleware matched statically-rendered pages:
 
         ${yellowBright([...matchingMiddleware].map((mid) => `- /${mid}/_middleware`).join('\n'))}
+
+        ────────────────────────────────────────────────────────────────
       `,
     )
     // There could potentially be thousands of matching pages, so we don't want to spam the console with this
@@ -128,6 +165,40 @@ exports.moveStaticPages = async ({ netlifyConfig, target, i18n }) => {
           The following files matched middleware and were not moved to the CDN:
 
           ${yellowBright([...matchedPages].map((mid) => `- ${mid}`).join('\n'))}
+
+          ────────────────────────────────────────────────────────────────
+        `,
+      )
+    }
+  }
+
+  if (matchedRedirects.size !== 0 || matchedRewrites.size !== 0) {
+    console.log(
+      yellowBright(outdent`
+        Skipped moving ${
+          matchedRedirects.size + matchedRewrites.size
+        } files because they match redirects or beforeFiles rewrites, so cannot be deployed to the CDN and will be served from the origin instead.
+      `),
+    )
+    if (matchedRedirects.size < 50 && matchedRedirects.size !== 0) {
+      console.log(
+        outdent`
+          The following files matched redirects and were not moved to the CDN:
+
+          ${yellowBright([...matchedRedirects].map((mid) => `- ${mid}`).join('\n'))}
+
+          ────────────────────────────────────────────────────────────────
+        `,
+      )
+    }
+    if (matchedRewrites.size < 50 && matchedRewrites.size !== 0) {
+      console.log(
+        outdent`
+          The following files matched beforeFiles rewrites and were not moved to the CDN:
+
+          ${yellowBright([...matchedRewrites].map((mid) => `- ${mid}`).join('\n'))}
+
+          ────────────────────────────────────────────────────────────────
         `,
       )
     }
@@ -151,3 +222,4 @@ exports.movePublicFiles = async ({ appDir, publish }) => {
     await copy(publicDir, `${publish}/`)
   }
 }
+/* eslint-enable max-lines */


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Ensures that if a file would match a redirect or `beforeFiles` rewrite, it isn;t served from the CDN as that would prevent the rule from being applied. We could potentially be smarter and check if we can represent the rule using Netlify redirects, but that would be quite complicated to achieve and wouldn't work for lots of scenarios

### Test plan

1. Visit these pages and ensure they redirect to the locale root: [en](https://deploy-preview-832--netlify-plugin-nextjs-demo.netlify.app/redirectme) [fr](https://deploy-preview-832--netlify-plugin-nextjs-demo.netlify.app/fr/redirectme)
2. Visit these pages and ensure that they show the image page, rather than an error message: [en](https://deploy-preview-832--netlify-plugin-nextjs-demo.netlify.app/old/image/) [fr](https://deploy-preview-832--netlify-plugin-nextjs-demo.netlify.app/fr/old/image/)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #819

![image](https://user-images.githubusercontent.com/213306/143029415-555384a7-5e80-4a25-bb9b-292f82fb83f6.png)
