### PR TITLE
feat: add support for Next env vars

### DIFF
--- a/demos/default/.env.production
+++ b/demos/default/.env.production
@@ -1,0 +1,1 @@
+HELLO_WORLD="Hello Production"

--- a/demos/default/pages/api/hello.js
+++ b/demos/default/pages/api/hello.js
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  res.status(200).json({ name: 'John Doe', query: req.query })
+  res.status(200).json({ name: 'John Doe', query: req.query, env: process.env.HELLO_WORLD })
 }

--- a/demos/default/pages/getServerSideProps/[id].js
+++ b/demos/default/pages/getServerSideProps/[id].js
@@ -1,7 +1,7 @@
 import Error from 'next/error'
 import Link from 'next/link'
 
-const Show = ({ errorCode, show }) => {
+const Show = ({ errorCode, show, env }) => {
   // If show item was not found, render 404 page
   if (errorCode) {
     return <Error statusCode={errorCode} />
@@ -15,7 +15,7 @@ const Show = ({ errorCode, show }) => {
         <br />
         Refresh the page to see server-side rendering in action.
         <br />
-        You can also try changing the ID to any other number between 1-10000.
+        You can also try changing the ID to any other number between 1-10000. Env: {env}
       </p>
 
       <hr />
@@ -46,6 +46,7 @@ export const getServerSideProps = async ({ params }) => {
     props: {
       errorCode,
       show: data,
+      env: process.env.HELLO_WORLD || null,
     },
   }
 }

--- a/demos/default/pages/getStaticProps/env.js
+++ b/demos/default/pages/getStaticProps/env.js
@@ -1,0 +1,24 @@
+import Link from 'next/link'
+
+const Env = ({ env }) => (
+  <div>
+    <p>This page uses getStaticProps() to populate env vars.</p>
+
+    <hr />
+    <p>env: {env}</p>
+
+    <Link href="/">
+      <a>Go back home</a>
+    </Link>
+  </div>
+)
+
+export function getStaticProps(context) {
+  return {
+    props: {
+      env: process.env.HELLO_WORLD || null,
+    },
+  }
+}
+
+export default Env

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "publish:test": "npm test",
     "test": "run-s build build:demo test:jest",
     "test:jest": "jest",
+    "test:jest:update": "jest --updateSnapshot",
+    "test:update": "run-s build build:demo test:jest:update",
     "prepare": "npm run build",
     "clean": "rimraf lib",
     "build": "tsc",

--- a/src/helpers/config.js
+++ b/src/helpers/config.js
@@ -190,6 +190,10 @@ exports.configureHandlerFunctions = ({ netlifyConfig, publish, ignore = [] }) =>
     netlifyConfig.functions[functionName].node_bundler = 'nft'
     netlifyConfig.functions[functionName].included_files ||= []
     netlifyConfig.functions[functionName].included_files.push(
+      '.env',
+      '.env.local',
+      '.env.production',
+      '.env.production.local',
       `${publish}/server/**`,
       `${publish}/serverless/**`,
       `${publish}/*.json`,

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -18,6 +18,7 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/getServerSideProps/all/[[...slug]].js')
         require.resolve('../../../.next/server/pages/getServerSideProps/static.js')
         require.resolve('../../../.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/env.js')
         require.resolve('../../../.next/server/pages/getStaticProps/static.js')
         require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
@@ -52,6 +53,7 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/getServerSideProps/all/[[...slug]].js')
         require.resolve('../../../.next/server/pages/getServerSideProps/static.js')
         require.resolve('../../../.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/env.js')
         require.resolve('../../../.next/server/pages/getStaticProps/static.js')
         require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
@@ -74,6 +76,8 @@ Array [
   "en/getStaticProps/1.json",
   "en/getStaticProps/2.html",
   "en/getStaticProps/2.json",
+  "en/getStaticProps/env.html",
+  "en/getStaticProps/env.json",
   "en/getStaticProps/static.html",
   "en/getStaticProps/static.json",
   "en/getStaticProps/withFallback/3.html",
@@ -92,12 +96,16 @@ Array [
   "en/previewTest.html",
   "en/previewTest.json",
   "en/static.html",
+  "es/getStaticProps/env.html",
+  "es/getStaticProps/env.json",
   "es/getStaticProps/static.html",
   "es/getStaticProps/static.json",
   "es/image.html",
   "es/previewTest.html",
   "es/previewTest.json",
   "es/static.html",
+  "fr/getStaticProps/env.html",
+  "fr/getStaticProps/env.json",
   "fr/getStaticProps/static.html",
   "fr/getStaticProps/static.json",
   "fr/image.html",

--- a/test/index.js
+++ b/test/index.js
@@ -296,6 +296,10 @@ describe('onBuild()', () => {
 
     await plugin.onBuild(defaultArgs)
     const includes = [
+      '.env',
+      '.env.local',
+      '.env.production',
+      '.env.production.local',
       '.next/server/**',
       '.next/serverless/**',
       '.next/*.json',


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Adds support for [Next env var files](https://nextjs.org/docs/basic-features/environment-variables)

### Test plan

Check the following pages for the string "Hello Production"

1.  https://deploy-preview-842--netlify-plugin-nextjs-demo.netlify.app/getStaticProps/env
2. https://deploy-preview-842--netlify-plugin-nextjs-demo.netlify.app/api/hello
3. https://deploy-preview-842--netlify-plugin-nextjs-demo.netlify.app/getServerSideProps/1

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![image](https://user-images.githubusercontent.com/213306/143471725-ba51f15f-197b-43de-b206-9609cc689ede.png)

Fixes  #823
