### PR TITLE
fix: correct root redirect when trailingSlash = false

### DIFF
--- a/src/helpers/redirects.ts
+++ b/src/helpers/redirects.ts
@@ -18,7 +18,7 @@ const generateLocaleRedirects = ({
   const redirects: NetlifyConfig['redirects'] = []
   // If the cookie is set, we need to redirect at the origin
   redirects.push({
-    from: `${basePath}${trailingSlash ? '/' : ''}`,
+    from: `${basePath}/`,
     to: HANDLER_FUNCTION_PATH,
     status: 200,
     force: true,
@@ -32,7 +32,7 @@ const generateLocaleRedirects = ({
     }
     redirects.push({
       from: `${basePath}/`,
-      to: `${basePath}/${locale}/`,
+      to: `${basePath}/${locale}${trailingSlash ? '/' : ''}`,
       status: 301,
       conditions: {
         Language: [locale],


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

The root level redirect when NEXT_LOCALE is set was incorrectly defined when trailingSlash was set to false.

<!-- Provide a brief summary of the change. -->

### Test plan

1. Set a test site to trailingSlash = false
2. Check that there is no redirect created with `from = ''` 

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #872 

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
