### PR TITLE
fix: bypass preview for static files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,7 @@ module.exports = {
 
     await generateRedirects({
       netlifyConfig,
-      nextConfig: { basePath, i18n, trailingSlash },
+      nextConfig: { basePath, i18n, trailingSlash, appDir },
     })
   },
 


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Currently we have a forced redirect to the handler funciton if preview mode is on, as it needs to bypass ODBs and SSG pages. However this means it also forces a rewrite for files from `public`, causing broken images and other static files. This PR adds no-op rewrites for any files from that directory, ensuring that they don't match the force redirect and are instead served from the CDN.

### Test plan

2. [Enable preview mode on the deploy preview](https://deploy-preview-918--netlify-plugin-nextjs-demo.netlify.app/api/enterPreview/)
3. [Load the image from the index page](https://deploy-preview-918--netlify-plugin-nextjs-demo.netlify.app/next-on-netlify.png) and check it is found

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Closes #753 
### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
