### PR TITLE
fix: handle Windows paths correctly

### DIFF
--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -1,8 +1,8 @@
 [build]
 command = "next build"
 publish = ".next"
+ignore = "echo CACHED_COMMIT_REF: $CACHED_COMMIT_REF COMMIT_REF: $COMMIT_REF && git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF ../../"
 
-# ignore = "echo CACHED_COMMIT_REF: $CACHED_COMMIT_REF COMMIT_REF: $COMMIT_REF && git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF ../../"
 [build.environment]
 # cache Cypress binary in local "node_modules" folder
 # so Netlify caches it

--- a/src/helpers/cache.ts
+++ b/src/helpers/cache.ts
@@ -1,7 +1,7 @@
-import { posix } from 'path'
+import { join } from 'path'
 
 export const restoreCache = async ({ cache, publish }) => {
-  const cacheDir = posix.join(publish, 'cache')
+  const cacheDir = join(publish, 'cache')
 
   if (await cache.restore(cacheDir)) {
     console.log('Next.js cache restored.')
@@ -11,9 +11,9 @@ export const restoreCache = async ({ cache, publish }) => {
 }
 
 export const saveCache = async ({ cache, publish }) => {
-  const cacheDir = posix.join(publish, 'cache')
+  const cacheDir = join(publish, 'cache')
 
-  const buildManifest = posix.join(publish, 'build-manifest.json')
+  const buildManifest = join(publish, 'build-manifest.json')
   if (await cache.save(cacheDir, { digests: [buildManifest] })) {
     console.log('Next.js cache saved.')
   } else {

--- a/src/helpers/functions.ts
+++ b/src/helpers/functions.ts
@@ -37,18 +37,16 @@ export const generateFunctions = async (
  * This is just so that the nft bundler knows about them. We'll eventually do this better.
  */
 export const generatePagesResolver = async ({
-  constants: { INTERNAL_FUNCTIONS_SRC, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC },
-  netlifyConfig,
+  constants: { INTERNAL_FUNCTIONS_SRC, FUNCTIONS_SRC = DEFAULT_FUNCTIONS_SRC, PUBLISH_DIR },
   target,
 }: {
   constants: NetlifyPluginConstants
-  netlifyConfig: NetlifyConfig
   target: string
 }): Promise<void> => {
   const functionsPath = INTERNAL_FUNCTIONS_SRC || FUNCTIONS_SRC
 
   const jsSource = await getPageResolver({
-    netlifyConfig,
+    publish: PUBLISH_DIR,
     target,
   })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const plugin: NetlifyPlugin = {
     configureHandlerFunctions({ netlifyConfig, ignore, publish: relative(process.cwd(), publish) })
 
     await generateFunctions(constants, appDir)
-    await generatePagesResolver({ netlifyConfig, target, constants })
+    await generatePagesResolver({ target, constants })
 
     await movePublicFiles({ appDir, outdir, publish })
 

--- a/src/templates/getPageResolver.ts
+++ b/src/templates/getPageResolver.ts
@@ -9,9 +9,9 @@ import { HANDLER_FUNCTION_NAME } from '../constants'
 // Generate a file full of require.resolve() calls for all the pages in the
 // build. This is used by the nft bundler to find all the pages.
 
-export const getPageResolver = async ({ netlifyConfig, target }) => {
+export const getPageResolver = async ({ publish, target }: { publish: string; target: string }) => {
   const functionDir = posix.resolve(posix.join('.netlify', 'functions', HANDLER_FUNCTION_NAME))
-  const root = posix.join(netlifyConfig.build.publish, target === 'server' ? 'server' : 'serverless', 'pages')
+  const root = posix.resolve(slash(publish), target === 'server' ? 'server' : 'serverless', 'pages')
 
   const pages = await glob('**/*.js', {
     cwd: root,

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -70,6 +70,76 @@ exports.resolvePages = () => {
 }"
 `;
 
+exports[`onBuild() generates a file referencing all when publish dir is a subdirectory 1`] = `
+"// This file is purely to allow nft to know about these pages. It should be temporary.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../web/.next/server/pages/_app.js')
+        require.resolve('../../../web/.next/server/pages/_document.js')
+        require.resolve('../../../web/.next/server/pages/_error.js')
+        require.resolve('../../../web/.next/server/pages/api/enterPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/exitPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/hello-background.js')
+        require.resolve('../../../web/.next/server/pages/api/hello.js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[id].js')
+        require.resolve('../../../web/.next/server/pages/deep/import.js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/all/[[...slug]].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/env.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/index.js')
+        require.resolve('../../../web/.next/server/pages/middle/_middleware.js')
+        require.resolve('../../../web/.next/server/pages/previewTest.js')
+        require.resolve('../../../web/.next/server/pages/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/shows/[id].js')
+    } catch {}
+}"
+`;
+
+exports[`onBuild() generates a file referencing all when publish dir is a subdirectory 2`] = `
+"// This file is purely to allow nft to know about these pages. It should be temporary.
+exports.resolvePages = () => {
+    try {
+        require.resolve('../../../web/.next/server/pages/_app.js')
+        require.resolve('../../../web/.next/server/pages/_document.js')
+        require.resolve('../../../web/.next/server/pages/_error.js')
+        require.resolve('../../../web/.next/server/pages/api/enterPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/exitPreview.js')
+        require.resolve('../../../web/.next/server/pages/api/hello-background.js')
+        require.resolve('../../../web/.next/server/pages/api/hello.js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/api/shows/[id].js')
+        require.resolve('../../../web/.next/server/pages/deep/import.js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/all/[[...slug]].js')
+        require.resolve('../../../web/.next/server/pages/getServerSideProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/env.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/static.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/index.js')
+        require.resolve('../../../web/.next/server/pages/middle/_middleware.js')
+        require.resolve('../../../web/.next/server/pages/previewTest.js')
+        require.resolve('../../../web/.next/server/pages/shows/[...params].js')
+        require.resolve('../../../web/.next/server/pages/shows/[id].js')
+    } catch {}
+}"
+`;
+
 exports[`onBuild() generates static files manifest 1`] = `
 Array [
   Array [


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Changes the way paths are generated for `getPageResolver`, because the current way is causing trouble on Windows. Updated the tests so that they're more able to catch this.

### Test plan

1. Ensure the tests pass on WIndows

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://user-images.githubusercontent.com/213306/145421299-8d43d41f-bf00-4f6d-8187-79f636eaa613.png)


Fixes #941

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
