### PR TITLE
fix: use `rawUrl` for path

### DIFF
--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -1,8 +1,8 @@
 [build]
 command = "next build"
 publish = ".next"
+ignore = "echo CACHED_COMMIT_REF: $CACHED_COMMIT_REF COMMIT_REF: $COMMIT_REF && git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF ../../"
 
-# ignore = "echo CACHED_COMMIT_REF: $CACHED_COMMIT_REF COMMIT_REF: $COMMIT_REF && git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF ../../"
 [build.environment]
 # cache Cypress binary in local "node_modules" folder
 # so Netlify caches it

--- a/src/templates/getHandler.ts
+++ b/src/templates/getHandler.ts
@@ -56,7 +56,7 @@ const makeHandler =
     return async (event, context) => {
       let requestMode = mode
       // Ensure that paths are encoded - but don't double-encode them
-      event.path = new URL(event.path, event.rawUrl).pathname
+      event.path = new URL(event.rawUrl).pathname
       // Next expects to be able to parse the query from the URL
       const query = new URLSearchParams(event.queryStringParameters).toString()
       event.path = query ? `${event.path}?${query}` : event.path


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Netlify Functions events have a bug where the `event.path` is decoded, so can end up with illegal characters. To work around this, this PR switches to using `rawUrl` directly, which is still encoded. This bug was manifesting when a URL contained an encoded `#` character, which if decoded would cause the rest of the URL to be treated as a fragment rather than part of the path.

### Test plan

1. Visit the Deploy Preview ([on this page](https://deploy-preview-954--netlify-plugin-nextjs-demo.netlify.app/shows/73/whatever/path/zIFeVeR%232711/you/want/)) 
2. Verify the path displayed in the page includes the `#` character (%23)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![image](https://user-images.githubusercontent.com/213306/145553105-d546a91c-790d-4bbe-9ec1-3fd5041e5a60.png)


Fixes #952

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
