### PR TITLE
chore: disable recording of cypress

### DIFF
--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -23,5 +23,5 @@ package = "@netlify/plugin-local-install-core"
 package = "netlify-plugin-cypress"
 
 [context.deploy-preview.plugins.inputs]
-record = true
+record = false
 configFile = "../../cypress/config/ci.json"

--- a/demos/nx-next-monorepo-demo/netlify.toml
+++ b/demos/nx-next-monorepo-demo/netlify.toml
@@ -24,5 +24,5 @@ package = "@netlify/plugin-local-install-core"
 package = "netlify-plugin-cypress"
 
 [context.deploy-preview.plugins.inputs]
-record = true
+record = false
 configFile = "../../cypress/config/nx-demo.json"

--- a/demos/static-root/netlify.toml
+++ b/demos/static-root/netlify.toml
@@ -21,5 +21,5 @@ package = "@netlify/plugin-local-install-core"
 package = "netlify-plugin-cypress"
 
 [context.deploy-preview.plugins.inputs]
-record = true
+record = false
 configFile = "../../cypress/config/static-root.json"


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary
Sadly, running three concurrent sites with the cypress plugin overwrites previous runs. I'll move to three github actions instead

### Test plan

See cypress not do status check anymore

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
