### PR TITLE
fix: warn if publish is "out"

### DIFF
--- a/src/helpers/verification.ts
+++ b/src/helpers/verification.ts
@@ -61,12 +61,17 @@ export const checkNextSiteHasBuilt = ({
   failBuild: FailBuild
 }): void | never => {
   if (!existsSync(path.join(publish, 'BUILD_ID'))) {
+    const outWarning =
+      path.basename(publish) === 'out'
+        ? `Your publish directory is set to "out", but in most cases it should be ".next".`
+        : `In most cases it should be set to ".next", unless you have chosen a custom "distDir" in your Next config.`
+
     return failBuild(outdent`
       The directory "${path.relative(
         process.cwd(),
         publish,
-      )}" does not contain a Next.js production build. Perhaps the build command was not run, or you specified the wrong publish directory. 
-      In most cases it should be set to the site's ".next" directory path, unless you have chosen a custom "distDir" in your Next config. 
+      )}" does not contain a Next.js production build. Perhaps the build command was not run, or you specified the wrong publish directory.
+      ${outWarning}
       If you are using "next export" then the Essential Next.js plugin should be removed. See https://ntl.fyi/remove-plugin for details.
     `)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -208,11 +208,26 @@ describe('onBuild()', () => {
   test("fails if BUILD_ID doesn't exist", async () => {
     await moveNextDist()
     await unlink(path.join(process.cwd(), '.next/BUILD_ID'))
-    const failBuild = jest.fn().mockImplementation(() => {
-      throw new Error('BUILD_ID does not exist')
+    const failBuild = jest.fn().mockImplementation((err) => {
+      throw new Error(err)
     })
+    expect(() => plugin.onBuild({ ...defaultArgs, utils: { ...utils, build: { failBuild } } })).rejects.toThrow(
+      `In most cases it should be set to ".next", unless you have chosen a custom "distDir" in your Next config.`,
+    )
+    expect(failBuild).toHaveBeenCalled()
+  })
 
-    expect(() => plugin.onBuild({ ...defaultArgs, utils: { ...utils, build: { failBuild } } })).rejects.toThrow()
+  test("fails with helpful warning if BUILD_ID doesn't exist and publish is 'out'", async () => {
+    await moveNextDist()
+    await unlink(path.join(process.cwd(), '.next/BUILD_ID'))
+    const failBuild = jest.fn().mockImplementation((err) => {
+      throw new Error(err)
+    })
+    netlifyConfig.build.publish = path.resolve('out')
+
+    expect(() => plugin.onBuild({ ...defaultArgs, utils: { ...utils, build: { failBuild } } })).rejects.toThrow(
+      `Your publish directory is set to "out", but in most cases it should be ".next".`,
+    )
     expect(failBuild).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

If the plugin can't find a build in the `publish` directory it fails the build with a warning to check that the build command has run and the publish dir is correct. This PR adds specific wording if the publish dir is "out", because that is the old default.

### Test plan

Change the `publish` dir in `netlify.toml` to `"out"`, then run a build, checking that it fails with a message including `Your publish directory is set to "out", but in most cases it should be ".next".`

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #975
![image](https://user-images.githubusercontent.com/213306/145818133-4c2638d0-5fcb-4699-aff6-a3795d11cfe0.png)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
