### PR TITLE
chore: revert ignore command

### DIFF
--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "echo CACHED_COMMIT_REF: $CACHED_COMMIT_REF COMMIT_REF: $COMMIT_REF && git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF ../../"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
 
 [build.environment]
 # cache Cypress binary in local "node_modules" folder

--- a/demos/nx-next-monorepo-demo/netlify.toml
+++ b/demos/nx-next-monorepo-demo/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "npm run build"
 publish = "dist/apps/demo-monorepo/.next"
-ignore = "git diff --exit-code $CACHED_COMMIT_REF $COMMIT_REF ../../"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
 
 [dev]
 command = "npm run start"

--- a/demos/static-root/netlify.toml
+++ b/demos/static-root/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
 
 [build.environment]
 # cache Cypress binary in local "node_modules" folder


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Reverts the `ignore` commands in the test site, which were changed when diagnosing the missing builds problem
