### PR TITLE
fix: prevent infinite loop when `/` is ISR

### DIFF
--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -111,7 +111,7 @@ export const moveStaticPages = async ({
   Object.entries(prerenderManifest.routes).forEach(([route, { initialRevalidateSeconds }]) => {
     if (initialRevalidateSeconds) {
       // Find all files used by ISR routes
-      const trimmedPath = route.slice(1)
+      const trimmedPath = route === '/' ? 'index' : route.slice(1)
       isrFiles.add(`${trimmedPath}.html`)
       isrFiles.add(`${trimmedPath}.json`)
       if (initialRevalidateSeconds < MINIMUM_REVALIDATE_SECONDS) {


### PR DESCRIPTION
### Summary

We avoid moving ISR pages to the CDN, by checking the files against the list of routes. This PR fixes a bug where if `/` was ISR and there were no locales defined, `index.html` would be moved to the CDN. This would cause an infinite loop where it tried to load itself.

### Test plan

I didn't think it worth creating a new test site for this, but it can be tested by making `static-root` use ISR for `index.js`, and disabling i18n.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
