### PR TITLE
Update large-functions.md

### DIFF
--- a/docs/large-functions.md
+++ b/docs/large-functions.md
@@ -18,9 +18,3 @@ solution. The list of largest files shown in the build logs will help you see wh
 
   If you do need large modules at runtime (e.g. if you are running Puppeteer in a Next API route), consider changing to
   a Netlify function which will have less overhead than the equivalent Next.js function.
-
-- **Large numbers of pre-rendered pages** If you have a very large number of pre-rendered pages, these can take up a lot
-  of space in the function. There are two approaches to fixing this. One is to consider deferring the building of the
-  pages. If you return `fallback: "blocking"` from `getStaticPaths` the rendering will be deferred until the first user
-  requests the page. This is a good choice for low-traffic pages. It reduces build and deploy time, and can make your
-  bundle a lot smaller.


### PR DESCRIPTION
Removing this line from the docs since I don't think it applies now that MOVE_STATIC_FILES is the default behaviour

> - **Large numbers of pre-rendered pages** If you have a very large number of pre-rendered pages, these can take up a lot
  of space in the function. There are two approaches to fixing this. One is to consider deferring the building of the
  pages. If you return `fallback: "blocking"` from `getStaticPaths` the rendering will be deferred until the first user
  requests the page. This is a good choice for low-traffic pages. It reduces build and deploy time, and can make your
  bundle a lot smaller.

<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

<!-- Provide a brief summary of the change. -->

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
