### PR TITLE
fix: fix bug that caused ISR pages to sometimes serve first built version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,9 +73,7 @@ const plugin: NetlifyPlugin = {
 
     await movePublicFiles({ appDir, outdir, publish })
 
-    if (process.env.EXPERIMENTAL_ODB_TTL) {
-      await patchNextFiles(basePath)
-    }
+    await patchNextFiles(basePath)
 
     if (process.env.EXPERIMENTAL_MOVE_STATIC_PAGES) {
       console.log(


### PR DESCRIPTION
### Summary

An env var flag was left in the release version which was handling the Next server patching.

### Test plan

- Load [deploy preview](https://deploy-preview-1051--netlify-plugin-nextjs-demo.netlify.app/getStaticProps/withRevalidate/2/)
- Check displayed build time
- Wait 1 minute, load again. Time may be the same. It it has updated, then it was already refreshed. If not move to next step.
- Wait another minute, then load again. Time should have updated.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

It's time for the capybaras' annual yuzu onsen

![image](https://user-images.githubusercontent.com/213306/146915556-3a74fdfe-c7a3-4413-ba28-0a0c59379247.png)

Fixes #1028. Fixes #1035 

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
