### PR TITLE
fix: force React to use production env

### DIFF
--- a/cypress/integration/default/default.spec.ts
+++ b/cypress/integration/default/default.spec.ts
@@ -5,20 +5,24 @@ describe('Default site', () => {
 
   it('loads home page', () => {
     cy.findByText('Next Demo!')
-    cy.findByTestId("list-server-side").within(() => {
-      cy.findAllByRole("link").should('have.length', 5)
+    cy.findByTestId('list-server-side').within(() => {
+      cy.findAllByRole('link').should('have.length', 5)
     })
 
-    cy.findByTestId("list-dynamic-pages").within(() => {
-      cy.findAllByRole("link").should('have.length', 3)
+    cy.findByTestId('list-dynamic-pages').within(() => {
+      cy.findAllByRole('link').should('have.length', 3)
     })
 
-    cy.findByTestId("list-catch-all").within(() => {
-      cy.findAllByRole("link").should('have.length', 3)
+    cy.findByTestId('list-catch-all').within(() => {
+      cy.findAllByRole('link').should('have.length', 3)
     })
 
-    cy.findByTestId("list-static").within(() => {
-      cy.findAllByRole("link").should('have.length', 2)
+    cy.findByTestId('list-static').within(() => {
+      cy.findAllByRole('link').should('have.length', 2)
     })
+  })
+
+  it('sets NODE_ENV', () => {
+    cy.findByText('NODE_ENV: production')
   })
 })

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -3,7 +3,7 @@ import dynamic from 'next/dynamic'
 const Header = dynamic(() => import(/* webpackChunkName: 'header' */ '../components/Header'), { ssr: true })
 import { useRouter } from 'next/router'
 
-const Index = ({ shows }) => {
+const Index = ({ shows, nodeEnv }) => {
   const { locale } = useRouter()
 
   return (
@@ -23,6 +23,7 @@ const Index = ({ shows }) => {
         <br />
         Refresh this page to see it change.
       </p>
+      <p>NODE_ENV: {nodeEnv}</p>
 
       <ul data-testid="list-server-side">
         {shows.map(({ id, name }) => (
@@ -215,7 +216,7 @@ Index.getInitialProps = async function () {
   const res = await fetch(server)
   const data = await res.json()
 
-  return { shows: data.slice(0, 5) }
+  return { shows: data.slice(0, 5), nodeEnv: process.env.NODE_ENV || null }
 }
 
 export default Index


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

If `NODE_ENV` is unset, React uses a development build, which is slower and [can cause errors](https://github.com/netlify/netlify-plugin-nextjs/issues/1047). By default `NODE_ENV` is not set in Lambdas, so this happens for SSR pages. This PR forces the env to `"production"` if unset

### Test plan

1. Visit deploy preview
2. Check for "NODE_ENV: production"

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #1047

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
