### PR TITLE
fix: handle `routes-manifest`s without `staticRoutes` defined

### DIFF
--- a/src/helpers/redirects.ts
+++ b/src/helpers/redirects.ts
@@ -139,8 +139,8 @@ export const generateRedirects = async ({
       )
     }
   })
-  // Add rewrites for all static SSR routes
-  staticRoutes.forEach((route) => {
+  // Add rewrites for all static SSR routes. This is Next 12+
+  staticRoutes?.forEach((route) => {
     if (staticRoutePaths.has(route.page) || isApiRoute(route.page)) {
       // Prerendered static routes are either handled by the CDN or are ISR
       return

--- a/src/helpers/types.ts
+++ b/src/helpers/types.ts
@@ -46,7 +46,7 @@ export interface RoutesManifest {
   redirects: Redirect[]
   headers: Header[]
   dynamicRoutes: DynamicRoute[]
-  staticRoutes: StaticRoute[]
+  staticRoutes?: StaticRoute[]
   dataRoutes: DataRoute[]
   i18n: I18n
   rewrites: Rewrites

--- a/test/index.js
+++ b/test/index.js
@@ -409,6 +409,16 @@ describe('onBuild()', () => {
     expect(readFileSync(handlerFile, 'utf8')).toMatch(`require("../../../.next/required-server-files.json")`)
     expect(readFileSync(odbHandlerFile, 'utf8')).toMatch(`require("../../../.next/required-server-files.json")`)
   })
+
+  test('handles empty routesManifest.staticRoutes', async () => {
+    await moveNextDist()
+    const manifestPath = path.resolve('.next/routes-manifest.json')
+    const routesManifest = await readJson(manifestPath)
+    delete routesManifest.staticRoutes
+    await writeJSON(manifestPath, routesManifest)
+    // The function is supposed to return undefined, but we want to check if it throws
+    expect(await plugin.onBuild(defaultArgs)).toBeUndefined()
+  })
 })
 
 describe('onPostBuild', () => {


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Pre-Next 12, static routes weren't included in the routes manifest. We deal with that here with an optional chain.

### Test plan

1. Check the unit test

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![capybara](https://static.wikia.nocookie.net/disney/images/6/65/Chispi.jpg/revision/latest?cb=20211226230826)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
