### PR TITLE
fix: don't use ODB for routes that match middleware

### DIFF
--- a/demos/default/local-plugin/package-lock.json
+++ b/demos/default/local-plugin/package-lock.json
@@ -1,14 +1,5 @@
 {
   "name": "local-plugin",
   "version": "1.0.0",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "local-plugin",
-      "version": "1.0.0",
-      "hasInstallScript": true,
-      "license": "ISC"
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/demos/default/pages/getStaticProps/withFallbackAndMiddleware/[...slug].js
+++ b/demos/default/pages/getStaticProps/withFallbackAndMiddleware/[...slug].js
@@ -1,0 +1,57 @@
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+
+const Show = ({ show }) => {
+  const router = useRouter()
+
+  // This is never shown on Netlify. We just need it for NextJS to be happy,
+  // because NextJS will render a fallback HTML page.
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div>
+      <p>
+        Check the network panel for the header <code>x-middleware-date</code> to ensure that it is running
+      </p>
+
+      <hr />
+
+      <h1>Show #{show.id}</h1>
+      <p>{show.name}</p>
+
+      <hr />
+
+      <Link href="/">
+        <a>Go back home</a>
+      </Link>
+    </div>
+  )
+}
+
+export async function getStaticPaths() {
+  // Set the paths we want to pre-render
+  const paths = [{ params: { slug: ['my', 'path', '1'] } }, { params: { slug: ['my', 'path', '2'] } }]
+
+  // We'll pre-render these paths at build time.
+  // { fallback: true } means other routes will be rendered at runtime.
+  return { paths, fallback: true }
+}
+
+export async function getStaticProps({ params }) {
+  // The ID to render
+  const { slug } = params
+  const id = slug[slug.length - 1]
+
+  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const data = await res.json()
+
+  return {
+    props: {
+      show: data,
+    },
+  }
+}
+
+export default Show

--- a/demos/default/pages/getStaticProps/withFallbackAndMiddleware/[id].js
+++ b/demos/default/pages/getStaticProps/withFallbackAndMiddleware/[id].js
@@ -1,0 +1,55 @@
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+
+const Show = ({ show }) => {
+  const router = useRouter()
+
+  // This is never shown on Netlify. We just need it for NextJS to be happy,
+  // because NextJS will render a fallback HTML page.
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div>
+      <p>
+        Check the network panel for the header <code>x-middleware-date</code> to ensure that it is running
+      </p>
+      <hr />
+
+      <h1>Show #{show.id}</h1>
+      <p>{show.name}</p>
+
+      <hr />
+
+      <Link href="/">
+        <a>Go back home</a>
+      </Link>
+    </div>
+  )
+}
+
+export async function getStaticPaths() {
+  // Set the paths we want to pre-render
+  const paths = [{ params: { id: '3' } }, { params: { id: '4' } }]
+
+  // We'll pre-render these paths at build time.
+  // { fallback: true } means other routes will be rendered at runtime.
+  return { paths, fallback: true }
+}
+
+export async function getStaticProps({ params }) {
+  // The ID to render
+  const { id } = params
+
+  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const data = await res.json()
+
+  return {
+    props: {
+      show: data,
+    },
+  }
+}
+
+export default Show

--- a/demos/default/pages/getStaticProps/withFallbackAndMiddleware/_middleware.js
+++ b/demos/default/pages/getStaticProps/withFallbackAndMiddleware/_middleware.js
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server'
+
+export function middleware() {
+  const res = NextResponse.next()
+  res.headers.set('x-middleware-date', new Date().toISOString())
+  return res
+}

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -8,7 +8,11 @@ const Index = ({ shows, nodeEnv }) => {
 
   return (
     <div>
-      <img src="/next-on-netlify.png" alt="NextJS on Netlify Banner" className='self-center w-full max-h-80 max-w-5xl m-auto' />
+      <img
+        src="/next-on-netlify.png"
+        alt="NextJS on Netlify Banner"
+        className="self-center w-full max-h-80 max-w-5xl m-auto"
+      />
 
       <div>
         <Header />
@@ -18,7 +22,8 @@ const Index = ({ shows, nodeEnv }) => {
         <h2>Server-Side Rendering</h2>
 
         <p>
-          This page is server-side rendered. It fetches a random list of five TV shows from the TVmaze REST API. Refresh this page to see it change.
+          This page is server-side rendered. It fetches a random list of five TV shows from the TVmaze REST API. Refresh
+          this page to see it change.
         </p>
         <code>NODE_ENV: {nodeEnv}</code>
 
@@ -86,8 +91,8 @@ const Index = ({ shows, nodeEnv }) => {
 
         <h2>Localization</h2>
         <p>
-          Localization (i18n) is supported! This demo uses <code>fr</code> with <code>en</code> as the default locale (at{' '}
-          <code>/</code>).
+          Localization (i18n) is supported! This demo uses <code>fr</code> with <code>en</code> as the default locale
+          (at <code>/</code>).
         </p>
         <strong>The current locale is {locale}</strong>
         <p>Click on the links below to see the above text change</p>
@@ -173,6 +178,11 @@ const Index = ({ shows, nodeEnv }) => {
           <li>
             <Link href="/middle">
               <a>Middleware</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withFallbackAndMiddleware/4">
+              <a>Middleware matching a pre-rendered dynamic route</a>
             </Link>
           </li>
         </ul>

--- a/src/helpers/files.ts
+++ b/src/helpers/files.ts
@@ -61,7 +61,7 @@ export const matchesRewrite = (file: string, rewrites: Rewrites): boolean => {
 export const getMiddleware = async (publish: string): Promise<Array<string>> => {
   const manifestPath = join(publish, 'server', 'middleware-manifest.json')
   if (existsSync(manifestPath)) {
-    const manifest = await readJson(manifestPath)
+    const manifest = await readJson(manifestPath, { throws: false })
     return manifest?.sortedMiddleware ?? []
   }
   return []

--- a/src/helpers/redirects.ts
+++ b/src/helpers/redirects.ts
@@ -114,7 +114,11 @@ const generateStaticIsrRewrites = ({
   i18n: NextConfig['i18n']
   buildId: string
   middleware: Array<string>
-}) => {
+}): {
+  staticRoutePaths: Set<string>
+  staticIsrRoutesThatMatchMiddleware: Array<string>
+  staticIsrRewrites: NetlifyConfig['redirects']
+} => {
   const staticIsrRoutesThatMatchMiddleware: Array<string> = []
   const staticRoutePaths = new Set<string>()
   const staticIsrRewrites: NetlifyConfig['redirects'] = []
@@ -180,7 +184,10 @@ const generateDynamicRewrites = ({
   i18n: NextConfig['i18n']
   buildId: string
   middleware: Array<string>
-}) => {
+}): {
+  dynamicRoutesThatMatchMiddleware: Array<string>
+  dynamicRewrites: NetlifyConfig['redirects']
+} => {
   const dynamicRewrites: NetlifyConfig['redirects'] = []
   const dynamicRoutesThatMatchMiddleware: Array<string> = []
   dynamicRoutes.forEach((route) => {

--- a/src/helpers/redirects.ts
+++ b/src/helpers/redirects.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines */
-import { NetlifyConfig } from '@netlify/build'
+import type { NetlifyConfig } from '@netlify/build'
 import { yellowBright } from 'chalk'
 import { readJSON } from 'fs-extra'
-import { NextConfig } from 'next'
-import { PrerenderManifest } from 'next/dist/build'
+import type { NextConfig } from 'next'
+import type { PrerenderManifest, SsgRoute } from 'next/dist/build'
 import { outdent } from 'outdent'
 import { join } from 'pathe'
 
@@ -21,7 +21,7 @@ import {
 } from './utils'
 
 const matchesMiddleware = (middleware: Array<string>, route: string): boolean =>
-  middleware?.some((middlewarePath) => route.startsWith(middlewarePath))
+  middleware.some((middlewarePath) => route.startsWith(middlewarePath))
 
 const generateLocaleRedirects = ({
   i18n,
@@ -71,7 +71,143 @@ export const generateStaticRedirects = ({
   }
 }
 
-// eslint-disable-next-line max-lines-per-function
+/**
+ * Routes that match middleware need to always use the SSR function
+ * This generates a rewrite for every middleware in every locale, both with and without a splat
+ */
+const generateMiddlewareRewrites = ({ basePath, middleware, i18n, buildId }) => {
+  const handlerRewrite = (from: string) => ({
+    from: `${basePath}${from}`,
+    to: HANDLER_FUNCTION_PATH,
+    status: 200,
+  })
+
+  return (
+    middleware
+      .map((route) => {
+        const unlocalized = [handlerRewrite(`${route}`), handlerRewrite(`${route}/*`)]
+        if (i18n?.locales?.length > 0) {
+          const localized = i18n.locales.map((locale) => [
+            handlerRewrite(`/${locale}${route}`),
+            handlerRewrite(`/${locale}${route}/*`),
+            handlerRewrite(`/_next/data/${buildId}/${locale}${route}/*`),
+          ])
+          // With i18n, all data routes are prefixed with the locale, but the HTML also has the unprefixed default
+          return [...unlocalized, ...localized]
+        }
+        return [...unlocalized, handlerRewrite(`/_next/data/${buildId}${route}/*`)]
+      })
+      // Flatten the array of arrays. Can't use flatMap as it might be 2 levels deep
+      .flat(2)
+  )
+}
+
+const generateStaticIsrRewrites = ({
+  staticRouteEntries,
+  basePath,
+  i18n,
+  buildId,
+  middleware,
+}: {
+  staticRouteEntries: Array<[string, SsgRoute]>
+  basePath: string
+  i18n: NextConfig['i18n']
+  buildId: string
+  middleware: Array<string>
+}) => {
+  const staticIsrRoutesThatMatchMiddleware: Array<string> = []
+  const staticRoutePaths = new Set<string>()
+  const staticIsrRewrites: NetlifyConfig['redirects'] = []
+  staticRouteEntries.forEach(([route, { initialRevalidateSeconds }]) => {
+    if (isApiRoute(route)) {
+      return
+    }
+    staticRoutePaths.add(route)
+
+    if (initialRevalidateSeconds === false) {
+      // These can be ignored, as they're static files handled by the CDN
+      return
+    }
+    // The default locale is served from the root, not the localised path
+    if (i18n?.defaultLocale && route.startsWith(`/${i18n.defaultLocale}/`)) {
+      route = route.slice(i18n.defaultLocale.length + 1)
+      staticRoutePaths.add(route)
+      if (matchesMiddleware(middleware, route)) {
+        staticIsrRoutesThatMatchMiddleware.push(route)
+      }
+      staticIsrRewrites.push(
+        ...redirectsForNextRouteWithData({
+          route,
+          dataRoute: routeToDataRoute(route, buildId, i18n.defaultLocale),
+          basePath,
+          to: ODB_FUNCTION_PATH,
+          force: true,
+        }),
+      )
+    } else if (matchesMiddleware(middleware, route)) {
+      //  Routes that match middleware can't use the ODB
+      staticIsrRoutesThatMatchMiddleware.push(route)
+    } else {
+      // ISR routes use the ODB handler
+      staticIsrRewrites.push(
+        // No i18n, because the route is already localized
+        ...redirectsForNextRoute({ route, basePath, to: ODB_FUNCTION_PATH, force: true, buildId, i18n: null }),
+      )
+    }
+  })
+
+  return {
+    staticRoutePaths,
+    staticIsrRoutesThatMatchMiddleware,
+    staticIsrRewrites,
+  }
+}
+
+/**
+ * Generate rewrites for all dynamic routes
+ */
+const generateDynamicRewrites = ({
+  dynamicRoutes,
+  prerenderedDynamicRoutes,
+  middleware,
+  basePath,
+  buildId,
+  i18n,
+}: {
+  dynamicRoutes: RoutesManifest['dynamicRoutes']
+  prerenderedDynamicRoutes: PrerenderManifest['dynamicRoutes']
+  basePath: string
+  i18n: NextConfig['i18n']
+  buildId: string
+  middleware: Array<string>
+}) => {
+  const dynamicRewrites: NetlifyConfig['redirects'] = []
+  const dynamicRoutesThatMatchMiddleware: Array<string> = []
+  dynamicRoutes.forEach((route) => {
+    if (isApiRoute(route.page)) {
+      return
+    }
+    if (route.page in prerenderedDynamicRoutes) {
+      if (matchesMiddleware(middleware, route.page)) {
+        dynamicRoutesThatMatchMiddleware.push(route.page)
+      } else {
+        dynamicRewrites.push(
+          ...redirectsForNextRoute({ buildId, route: route.page, basePath, to: ODB_FUNCTION_PATH, status: 200, i18n }),
+        )
+      }
+    } else {
+      // If the route isn't prerendered, it's SSR
+      dynamicRewrites.push(
+        ...redirectsForNextRoute({ route: route.page, buildId, basePath, to: HANDLER_FUNCTION_PATH, i18n }),
+      )
+    }
+  })
+  return {
+    dynamicRoutesThatMatchMiddleware,
+    dynamicRewrites,
+  }
+}
+
 export const generateRedirects = async ({
   netlifyConfig,
   nextConfig: { i18n, basePath, trailingSlash, appDir },
@@ -110,77 +246,25 @@ export const generateRedirects = async ({
   )
 
   const middleware = await getMiddleware(netlifyConfig.build.publish)
-  const routesThatMatchMiddleware = new Set<string>()
 
-  const handlerRewrite = (from: string) => ({
-    from: `${basePath}${from}`,
-    to: HANDLER_FUNCTION_PATH,
-    status: 200,
-  })
-
-  // Routes that match middleware need to always use the SSR function
-  // This generates a rewrite for every middleware in every locale, both with and without a splat
-  netlifyConfig.redirects.push(
-    ...middleware
-      .map((route) => {
-        const unlocalized = [handlerRewrite(`${route}`), handlerRewrite(`${route}/*`)]
-        if (i18n?.locales?.length > 0) {
-          const localized = i18n?.locales?.map((locale) => [
-            handlerRewrite(`/${locale}${route}`),
-            handlerRewrite(`/${locale}${route}/*`),
-            handlerRewrite(`/_next/data/${buildId}/${locale}${route}/*`),
-          ])
-          // With i18n, all data routes are prefixed with the locale, but the HTML also has the unprefixed default
-          return [...unlocalized, ...localized]
-        }
-        return [...unlocalized, handlerRewrite(`/_next/data/${buildId}${route}/*`)]
-      })
-      // Flatten the array of arrays. Can't use flatMap as it might be 2 levels deep
-      .flat(2),
-  )
+  netlifyConfig.redirects.push(...generateMiddlewareRewrites({ basePath, i18n, middleware, buildId }))
 
   const staticRouteEntries = Object.entries(prerenderedStaticRoutes)
 
-  const staticRoutePaths = new Set<string>()
+  const routesThatMatchMiddleware: Array<string> = []
 
-  // First add all static ISR routes
-  staticRouteEntries.forEach(([route, { initialRevalidateSeconds }]) => {
-    if (isApiRoute(route)) {
-      return
-    }
-    staticRoutePaths.add(route)
-
-    if (initialRevalidateSeconds === false) {
-      // These can be ignored, as they're static files handled by the CDN
-      return
-    }
-    // The default locale is served from the root, not the localised path
-    if (i18n?.defaultLocale && route.startsWith(`/${i18n.defaultLocale}/`)) {
-      route = route.slice(i18n.defaultLocale.length + 1)
-      staticRoutePaths.add(route)
-      if (matchesMiddleware(middleware, route)) {
-        routesThatMatchMiddleware.add(route)
-      }
-      netlifyConfig.redirects.push(
-        ...redirectsForNextRouteWithData({
-          route,
-          dataRoute: routeToDataRoute(route, buildId, i18n.defaultLocale),
-          basePath,
-          to: ODB_FUNCTION_PATH,
-          force: true,
-        }),
-      )
-    } else if (matchesMiddleware(middleware, route)) {
-      //  Routes that match middleware can't use the ODB
-      routesThatMatchMiddleware.add(route)
-    } else {
-      // ISR routes use the ODB handler
-      netlifyConfig.redirects.push(
-        // No i18n, because the route is already localized
-        ...redirectsForNextRoute({ route, basePath, to: ODB_FUNCTION_PATH, force: true, buildId, i18n: null }),
-      )
-    }
+  const { staticRoutePaths, staticIsrRewrites, staticIsrRoutesThatMatchMiddleware } = generateStaticIsrRewrites({
+    staticRouteEntries,
+    basePath,
+    i18n,
+    buildId,
+    middleware,
   })
+
+  routesThatMatchMiddleware.push(...staticIsrRoutesThatMatchMiddleware)
+
+  netlifyConfig.redirects.push(...staticIsrRewrites)
+
   // Add rewrites for all static SSR routes. This is Next 12+
   staticRoutes?.forEach((route) => {
     if (staticRoutePaths.has(route.page) || isApiRoute(route.page)) {
@@ -192,25 +276,16 @@ export const generateRedirects = async ({
     )
   })
   // Add rewrites for all dynamic routes (both SSR and ISR)
-  dynamicRoutes.forEach((route) => {
-    if (isApiRoute(route.page)) {
-      return
-    }
-    if (route.page in prerenderedDynamicRoutes) {
-      if (matchesMiddleware(middleware, route.page)) {
-        routesThatMatchMiddleware.add(route.page)
-      } else {
-        netlifyConfig.redirects.push(
-          ...redirectsForNextRoute({ buildId, route: route.page, basePath, to: ODB_FUNCTION_PATH, status: 200, i18n }),
-        )
-      }
-    } else {
-      // If the route isn't prerendered, it's SSR
-      netlifyConfig.redirects.push(
-        ...redirectsForNextRoute({ route: route.page, buildId, basePath, to: HANDLER_FUNCTION_PATH, i18n }),
-      )
-    }
+  const { dynamicRewrites, dynamicRoutesThatMatchMiddleware } = generateDynamicRewrites({
+    dynamicRoutes,
+    prerenderedDynamicRoutes,
+    middleware,
+    basePath,
+    buildId,
+    i18n,
   })
+  netlifyConfig.redirects.push(...dynamicRewrites)
+  routesThatMatchMiddleware.push(...dynamicRoutesThatMatchMiddleware)
 
   // Final fallback
   netlifyConfig.redirects.push({
@@ -219,15 +294,15 @@ export const generateRedirects = async ({
     status: 200,
   })
 
-  const middlewareMatches = routesThatMatchMiddleware.size
+  const middlewareMatches = new Set(routesThatMatchMiddleware).size
   if (middlewareMatches > 0) {
     console.log(
       yellowBright(outdent`
         There ${
           middlewareMatches === 1
-            ? `is one statically-generated or ISR route`
-            : `are ${middlewareMatches} statically-generated or ISR routes`
-        } that match a middleware function, which means they will always be served from the SSR function and will not use ISR or be served from the CDN.
+            ? `is one statically-generated or ISR route that matches`
+            : `are ${middlewareMatches} statically-generated or ISR routes that match`
+        } a middleware function. Matched routes will always be served from the SSR function and will not use ISR or be served from the CDN.
         If this was not intended, ensure that your middleware only matches routes that you intend to use SSR.
       `),
     )

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -2,13 +2,7 @@ import { NetlifyConfig } from '@netlify/build'
 import globby from 'globby'
 import { join } from 'pathe'
 
-import {
-  OPTIONAL_CATCH_ALL_REGEX,
-  CATCH_ALL_REGEX,
-  DYNAMIC_PARAMETER_REGEX,
-  ODB_FUNCTION_PATH,
-  HANDLER_FUNCTION_PATH,
-} from '../constants'
+import { OPTIONAL_CATCH_ALL_REGEX, CATCH_ALL_REGEX, DYNAMIC_PARAMETER_REGEX, HANDLER_FUNCTION_PATH } from '../constants'
 
 import { I18n } from './types'
 
@@ -51,8 +45,12 @@ export const netlifyRoutesForNextRouteWithData = ({ route, dataRoute }: { route:
   ...toNetlifyRoute(route),
 ]
 
+export const endsWithDynamicSegment = (route: string) => /\/(\*|(:[a-z]+))$/.test(route)
+
 export const routeToDataRoute = (route: string, buildId: string, locale?: string) =>
-  `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? '/index' : route}.json`
+  `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? '/index' : route}${
+    endsWithDynamicSegment(route) ? '' : '.json'
+  }`
 
 const netlifyRoutesForNextRoute = (route: string, buildId: string, i18n?: I18n): Array<string> => {
   if (!i18n?.locales?.length) {
@@ -76,16 +74,6 @@ const netlifyRoutesForNextRoute = (route: string, buildId: string, i18n?: I18n):
 }
 
 export const isApiRoute = (route: string) => route.startsWith('/api/') || route === '/api'
-
-export const targetForFallback = (fallback: string | false) => {
-  if (fallback === null || fallback === false) {
-    // fallback = null mean "blocking", which uses ODB. For fallback=false then anything prerendered should 404.
-    // However i18n pages may not have been prerendered, so we still need to hit the origin
-    return { to: ODB_FUNCTION_PATH, status: 200 }
-  }
-  // fallback = true is also ODB
-  return { to: ODB_FUNCTION_PATH, status: 200 }
-}
 
 export const redirectsForNextRoute = ({
   route,

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -45,12 +45,8 @@ export const netlifyRoutesForNextRouteWithData = ({ route, dataRoute }: { route:
   ...toNetlifyRoute(route),
 ]
 
-export const endsWithDynamicSegment = (route: string) => /\/(\*|(:[a-z]+))$/.test(route)
-
 export const routeToDataRoute = (route: string, buildId: string, locale?: string) =>
-  `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? '/index' : route}${
-    endsWithDynamicSegment(route) ? '' : '.json'
-  }`
+  `/_next/data/${buildId}${locale ? `/${locale}` : ''}${route === '/' ? '/index' : route}.json`
 
 const netlifyRoutesForNextRoute = (route: string, buildId: string, i18n?: I18n): Array<string> => {
   if (!i18n?.locales?.length) {

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -23,6 +23,9 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackAndMiddleware/[...slug].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackAndMiddleware/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackAndMiddleware/_middleware.js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
@@ -58,6 +61,9 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/getStaticProps/with-revalidate.js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[...slug].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackAndMiddleware/[...slug].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackAndMiddleware/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withFallbackAndMiddleware/_middleware.js')
         require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
@@ -93,6 +99,9 @@ exports.resolvePages = () => {
         require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackAndMiddleware/[...slug].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackAndMiddleware/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackAndMiddleware/_middleware.js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
@@ -128,6 +137,9 @@ exports.resolvePages = () => {
         require.resolve('../../../web/.next/server/pages/getStaticProps/with-revalidate.js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[...slug].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackAndMiddleware/[...slug].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackAndMiddleware/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackAndMiddleware/_middleware.js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
@@ -438,6 +450,126 @@ Array [
     },
     "force": true,
     "from": "/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/getStaticProps/withFallbackAndMiddleware",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/en/getStaticProps/withFallbackAndMiddleware",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/en/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/en/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/es/getStaticProps/withFallbackAndMiddleware",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/es/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/es/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/fr/getStaticProps/withFallbackAndMiddleware",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/fr/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/fr/getStaticProps/withFallbackAndMiddleware/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/middle",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/en/middle",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/en/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/en/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/es/middle",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/es/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/es/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/fr/middle",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/fr/middle/*",
+    "status": 200,
+    "to": "/.netlify/functions/___netlify-handler",
+  },
+  Object {
+    "from": "/_next/data/build-id/fr/middle/*",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
   },
@@ -1170,6 +1302,78 @@ Array [
   Object {
     "force": false,
     "from": "/fr/getStaticProps/withFallback/:slug/*",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withFallbackAndMiddleware/:id.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withFallbackAndMiddleware/:id",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withFallbackAndMiddleware/:id.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withFallbackAndMiddleware/:id",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withFallbackAndMiddleware/:id.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withFallbackAndMiddleware/:id",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withFallbackAndMiddleware/:slug/*",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withFallbackAndMiddleware/:slug/*",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withFallbackAndMiddleware/:slug/*",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withFallbackAndMiddleware/:slug/*",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withFallbackAndMiddleware/:slug/*",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withFallbackAndMiddleware/:slug/*",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -464,11 +464,6 @@ Array [
     "to": "/.netlify/functions/___netlify-handler",
   },
   Object {
-    "from": "/_next/data/build-id/getStaticProps/withFallbackAndMiddleware/*",
-    "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
-  },
-  Object {
     "from": "/en/getStaticProps/withFallbackAndMiddleware",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
@@ -520,11 +515,6 @@ Array [
   },
   Object {
     "from": "/middle/*",
-    "status": 200,
-    "to": "/.netlify/functions/___netlify-handler",
-  },
-  Object {
-    "from": "/_next/data/build-id/middle/*",
     "status": 200,
     "to": "/.netlify/functions/___netlify-handler",
   },
@@ -1302,78 +1292,6 @@ Array [
   Object {
     "force": false,
     "from": "/fr/getStaticProps/withFallback/:slug/*",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/_next/data/build-id/en/getStaticProps/withFallbackAndMiddleware/:id.json",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/getStaticProps/withFallbackAndMiddleware/:id",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/_next/data/build-id/es/getStaticProps/withFallbackAndMiddleware/:id.json",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/es/getStaticProps/withFallbackAndMiddleware/:id",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/_next/data/build-id/fr/getStaticProps/withFallbackAndMiddleware/:id.json",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/fr/getStaticProps/withFallbackAndMiddleware/:id",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/_next/data/build-id/en/getStaticProps/withFallbackAndMiddleware/:slug/*",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/getStaticProps/withFallbackAndMiddleware/:slug/*",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/_next/data/build-id/es/getStaticProps/withFallbackAndMiddleware/:slug/*",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/es/getStaticProps/withFallbackAndMiddleware/:slug/*",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/_next/data/build-id/fr/getStaticProps/withFallbackAndMiddleware/:slug/*",
-    "status": 200,
-    "to": "/.netlify/builders/___netlify-odb-handler",
-  },
-  Object {
-    "force": false,
-    "from": "/fr/getStaticProps/withFallbackAndMiddleware/:slug/*",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Routes that match middleware need to be served via SSR, because the middleware is run at the origin. This PR ensures that any routes that matches mdidleware is not served by an ODB, which was causing errors where results were persisted including the middleware.

### Test plan

1. Visit [the Deploy Preview](https://deploy-preview-1171--netlify-plugin-nextjs-demo.netlify.app/getStaticProps/withFallbackAndMiddleware/4/)
2. Check the network tab: there should be a header `x-middleware-date` inserted by middleware. Ensure that the date is up to date. Also ensure that `x-nf-render-mode` is `ssr`.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #1168, Fixes #1114

![capybara](https://pbs.twimg.com/media/FKHkiahUUBElzTN?format=jpg&name=small)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
