### PR TITLE
fix: correctly disable ISR disk flushing

### DIFF
--- a/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+
+const Show = ({ show, time }) => (
+  <div>
+    <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
+    <p>Ids 1 and 2 are prerendered</p>
+    <hr />
+
+    <h1>Show #{show.id}</h1>
+    <p>{show.name}</p>
+    <p>Rendered at {time} </p>
+    <hr />
+
+    <Link href="/">
+      <a>Go back home</a>
+    </Link>
+  </div>
+)
+
+export async function getStaticPaths() {
+  // Set the paths we want to pre-render
+  const paths = [{ params: { id: '1' } }, { params: { id: '2' } }]
+
+  // We'll pre-render only these paths at build time.
+
+  return { paths, fallback: 'blocking' }
+}
+
+export async function getStaticProps({ params }) {
+  // The ID to render
+  const { id } = params
+
+  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const data = await res.json()
+  const time = new Date().toLocaleTimeString()
+  return {
+    props: {
+      show: data,
+      time,
+    },
+    revalidate: 60,
+  }
+}
+
+export default Show

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -157,3 +157,20 @@ export const shouldSkip = (): boolean =>
   process.env.NEXT_PLUGIN_FORCE_RUN === '0' ||
   process.env.NETLIFY_NEXT_PLUGIN_SKIP === 'true' ||
   process.env.NETLIFY_NEXT_PLUGIN_SKIP === '1'
+
+/**
+ * Given an array of base paths and candidate modules, return the first one that exists
+ */
+export const findModuleFromBase = ({ paths, candidates }): string | null => {
+  for (const candidate of candidates) {
+    try {
+      const modulePath = require.resolve(candidate, { paths })
+      if (modulePath) {
+        return modulePath
+      }
+    } catch (error) {
+      console.error(error)
+    }
+  }
+  return null
+}

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -29,6 +29,7 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
         require.resolve('../../../.next/server/pages/index.js')
         require.resolve('../../../.next/server/pages/middle/_middleware.js')
         require.resolve('../../../.next/server/pages/previewTest.js')
@@ -67,6 +68,7 @@ exports.resolvePages = () => {
         require.resolve('../../../.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
         require.resolve('../../../.next/server/pages/index.js')
         require.resolve('../../../.next/server/pages/middle/_middleware.js')
         require.resolve('../../../.next/server/pages/previewTest.js')
@@ -105,6 +107,7 @@ exports.resolvePages = () => {
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
         require.resolve('../../../web/.next/server/pages/index.js')
         require.resolve('../../../web/.next/server/pages/middle/_middleware.js')
         require.resolve('../../../web/.next/server/pages/previewTest.js')
@@ -143,6 +146,7 @@ exports.resolvePages = () => {
         require.resolve('../../../web/.next/server/pages/getStaticProps/withFallbackBlocking/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/[id].js')
         require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallback/[id].js')
+        require.resolve('../../../web/.next/server/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js')
         require.resolve('../../../web/.next/server/pages/index.js')
         require.resolve('../../../web/.next/server/pages/middle/_middleware.js')
         require.resolve('../../../web/.next/server/pages/previewTest.js')
@@ -644,6 +648,30 @@ Array [
   Object {
     "force": true,
     "from": "/getStaticProps/withRevalidate/withFallback/2",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallbackBlocking/1.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/withFallbackBlocking/1",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallbackBlocking/2.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": true,
+    "from": "/getStaticProps/withRevalidate/withFallbackBlocking/2",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },
@@ -1364,6 +1392,42 @@ Array [
   Object {
     "force": false,
     "from": "/fr/getStaticProps/withRevalidate/withFallback/:id",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/en/getStaticProps/withRevalidate/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/getStaticProps/withRevalidate/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/es/getStaticProps/withRevalidate/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/es/getStaticProps/withRevalidate/withFallbackBlocking/:id",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/_next/data/build-id/fr/getStaticProps/withRevalidate/withFallbackBlocking/:id.json",
+    "status": 200,
+    "to": "/.netlify/builders/___netlify-odb-handler",
+  },
+  Object {
+    "force": false,
+    "from": "/fr/getStaticProps/withRevalidate/withFallbackBlocking/:id",
     "status": 200,
     "to": "/.netlify/builders/___netlify-odb-handler",
   },


### PR DESCRIPTION
### Summary

We need to patch the Next server source file because Next doesn't allow non-Vercel hosts to disable flushing of ISR pages to disk. In a recent update, the code in question was moved from `next-server` to `base-server`, meaning that the patch was not applied. This meant that ISR pages were serving the original built files rather than the updated version. This caused #1189 and possibly #1162.

This PR makes the patching process more robust, and introduces tests to ensure the patching is working in future

### Test plan

1. Visit [the Deploy Preview](https://deploy-preview-1190--netlify-plugin-nextjs-demo.netlify.app/getStaticProps/withRevalidate/withFallbackBlocking/2/)
2. Wait for a minute
3. Visit deploy preview again and ensure that the time has updated to near the current time, and not reverted to the build time

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Possibly #1189 and #1162, but I'm not going to auto-close until the fix is confirmed.

![capybara](https://pbs.twimg.com/media/FKiFb5lXEAM4NCQ?format=jpg&name=small)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
