### PR TITLE
ci: split canary tests from latest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,30 @@ jobs:
         if: "${{ matrix.node-version == '*' }}"
       - name: Run tests against next@latest
         run: npm test
+  canary:
+    name: Unit tests (Canary)
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node-version: [12, '*']
+        exclude:
+          - os: macOS-latest
+            node-version: 12
+          - os: windows-latest
+            node-version: 12
+      fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          check-latest: true
+      - name: NPM Install
+        run: npm ci
       - name: Install Next.js Canary
         run: npm install -D next@canary --legacy-peer-deps
       - name: Run tests against next@canary


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Currently we test `next@latest` and `next@canary` consecutively in the same test. This PR splits them out so that they can run faster and so canary tests can be optional.

### Test plan

1. Observe the tests both run. Canary will fail on a TypeScript error

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![capybara](https://pbs.twimg.com/media/FNCcHQUXwAAx_RG?format=jpg&name=medium)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
