### PR TITLE
fix: change working directory to site root in SSR

### DIFF
--- a/demos/default/pages/api/hello.js
+++ b/demos/default/pages/api/hello.js
@@ -1,5 +1,5 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 
 export default (req, res) => {
-  res.status(200).json({ name: 'John Doe', query: req.query, env: process.env.HELLO_WORLD })
+  res.status(200).json({ name: 'John Doe', query: req.query, env: process.env.HELLO_WORLD, cwd: process.cwd() })
 }

--- a/src/templates/getHandler.ts
+++ b/src/templates/getHandler.ts
@@ -27,6 +27,11 @@ type Mutable<T> = {
 // We return a function and then call `toString()` on it to serialise it as the launcher function
 // eslint-disable-next-line max-params
 const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[string, string]> = [], mode = 'ssr') => {
+  // Change working directory into the site root
+  const dir = path.resolve(__dirname, app)
+
+  process.chdir(dir)
+
   // This is just so nft knows about the page entrypoints. It's not actually used
   try {
     // eslint-disable-next-line node/no-missing-require
@@ -65,7 +70,7 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
     const NextServer: NextServerType = getNextServer()
     const nextServer = new NextServer({
       conf,
-      dir: path.resolve(__dirname, app),
+      dir,
       customServer: false,
       hostname: url.hostname,
       port,


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Next.js expects the cwd to be the site root. In some cases with monorepos that isn't the case, which can cause problems with packages that expect to be able to resolve things such as config files relative to the root. This PR changes the working directory to the site root as part of the handler bootstrap.

### Test plan

1. Visit `/api/hello` in the default deploy preview, and check that `cwd` is the site root.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![capybara and babies](https://pbs.twimg.com/media/FN6qCIjWUAonr-l?format=jpg&name=small)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
