### PR TITLE
fix: correctly find site root when using SSR with Nx

### DIFF
--- a/demos/nx-next-monorepo-demo/apps/demo-monorepo/pages/api/index.js
+++ b/demos/nx-next-monorepo-demo/apps/demo-monorepo/pages/api/index.js
@@ -1,0 +1,7 @@
+// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
+
+export default function handler(req, res) {
+  res.status(200).json({
+    body: 'Hello world',
+  });
+}

--- a/src/templates/getHandler.ts
+++ b/src/templates/getHandler.ts
@@ -27,10 +27,12 @@ type Mutable<T> = {
 // We return a function and then call `toString()` on it to serialise it as the launcher function
 // eslint-disable-next-line max-params
 const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[string, string]> = [], mode = 'ssr') => {
-  // Change working directory into the site root
+  // Change working directory into the site root, unless using Nx, which moves the
+  // dist directory and handles this itself
   const dir = path.resolve(__dirname, app)
-
-  process.chdir(dir)
+  if (pageRoot.startsWith(dir)) {
+    process.chdir(dir)
+  }
 
   // This is just so nft knows about the page entrypoints. It's not actually used
   try {


### PR DESCRIPTION
### Summary

The handler currently changes the working directory to the site root, however if the site uses Nx the site root is moved within a 'dist' folder and SSR routes consequently fail.

### Test plan

1. Visit the Deploy Preview and check the /api route returns 'Hello World' json output

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #1278 

![](https://www.australiangeographic.com.au/wp-content/uploads/2018/06/Pygmy-Possum_Amanda-McLean-Copy-1.jpg)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
