### PR TITLE
fix: :bug: include terser bundle into netlify functions

### DIFF
--- a/cypress/integration/default/preview.spec.ts
+++ b/cypress/integration/default/preview.spec.ts
@@ -2,7 +2,7 @@ describe('Preview Mode', () => {
   it('enters and exits preview mode', () => {
     // preview mode is off by default
     cy.visit('/previewTest')
-    cy.findByText('Is preview? No')
+    cy.findByText('Is preview? No', {selector: 'h1'})
 
     // enter preview mode
     cy.request('/api/enterPreview').then((response) => {

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -76,7 +76,6 @@ export const configureHandlerFunctions = ({ netlifyConfig, publish, ignore = [] 
         `!${nextRoot}/dist/next-server/server/lib/squoosh/**/*.wasm`,
         `!${nextRoot}/dist/compiled/webpack/bundle4.js`,
         `!${nextRoot}/dist/compiled/webpack/bundle5.js`,
-        `!${nextRoot}/dist/compiled/terser/bundle.min.js`,
       )
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -358,7 +358,6 @@ describe('onBuild()', () => {
       `!node_modules/next/dist/next-server/server/lib/squoosh/**/*.wasm`,
       '!node_modules/next/dist/compiled/webpack/bundle4.js',
       '!node_modules/next/dist/compiled/webpack/bundle5.js',
-      '!node_modules/next/dist/compiled/terser/bundle.min.js',
       '!node_modules/sharp/**/*',
     ]
     // Relative paths in Windows are different


### PR DESCRIPTION
Resolves issues where AMP would work locally, but not on a deployed site.

<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary
Someone had reported an issue where they were able to see that pages configured for AMP were working in their local environments, but not when they were deployed to Netlify.

In testing, it appeared that the `terser` package was needed but was being omitted from the netlify function `.zip` file generated at the `onBuild` step.

Removing the line that omitted the terser bundle resolves the issue.

### Test plan

1. Visit the Deploy Preview

The test deploy site has the home page configured as a hybrid AMP page. This means that you can test both the non-AMP and AMP views.

AMP URL: https://624b075121937b095892dd5c--amp-nextjs-investigation-with-ci.netlify.app?amp=1
Non-AMP URL: https://624b075121937b095892dd5c--amp-nextjs-investigation-with-ci.netlify.app/

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Google AMP Test Results for deploy site: https://search.google.com/test/amp/result?id=4llAXD5fMCWJiKavPHv_mg

![baby duck](https://user-images.githubusercontent.com/5655473/161576991-1c59a2bd-ccd7-4eb2-b07d-dea12293ae20.jpg)


### Standard checks:
- [ ] Check the Deploy Preview's Demo site for your PR's functionality
