### PR TITLE
ci: :sparkles: run tests on a nightly basis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: Plugin Tests
 
 on:
+  pull_request:
   push:
     branches: [main]
-  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
             node-version: 12
       fail-fast: false
 
+    if: github.ref_name == 'main'
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
### Summary

Runs the tests on a nightly basis. Also only run the canary tests on the `main` branch rather than on every push to a development/feature branch.

### Test plan

This affects Github Actions testing schedule configuration so no deploy site testing is needed

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![working_dog](https://user-images.githubusercontent.com/5655473/162767560-7ebb64b2-6878-473f-90c7-fcf1e6efd3e2.png)

