### PR TITLE
fix: pass x-middleware-rewrite header to client

### DIFF
--- a/demos/middleware/pages/index.js
+++ b/demos/middleware/pages/index.js
@@ -1,5 +1,5 @@
 import Head from 'next/head'
-import Image from 'next/image'
+import Link from 'next/link'
 import styles from '../styles/Home.module.css'
 
 export default function Home() {
@@ -16,54 +16,8 @@ export default function Home() {
           Welcome to <a href="https://nextjs.org">Next.js!</a>
         </h1>
 
-        <p className={styles.description}>
-          Get started by editing{' '}
-          <code className={styles.code}>pages/index.js</code>
-        </p>
-
-        <div className={styles.grid}>
-          <a href="https://nextjs.org/docs" className={styles.card}>
-            <h2>Documentation &rarr;</h2>
-            <p>Find in-depth information about Next.js features and API.</p>
-          </a>
-
-          <a href="https://nextjs.org/learn" className={styles.card}>
-            <h2>Learn &rarr;</h2>
-            <p>Learn about Next.js in an interactive course with quizzes!</p>
-          </a>
-
-          <a
-            href="https://github.com/vercel/next.js/tree/canary/examples"
-            className={styles.card}
-          >
-            <h2>Examples &rarr;</h2>
-            <p>Discover and deploy boilerplate example Next.js projects.</p>
-          </a>
-
-          <a
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-            className={styles.card}
-          >
-            <h2>Deploy &rarr;</h2>
-            <p>
-              Instantly deploy your Next.js site to a public URL with Vercel.
-            </p>
-          </a>
-        </div>
+        <p><Link href="/shows/rewriteme">Rewrite me</Link></p>
       </main>
-
-      <footer className={styles.footer}>
-        <a
-          href="https://vercel.com?utm_source=create-next-app&utm_medium=default-template&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Powered by{' '}
-          <span className={styles.logo}>
-            <Image src="/vercel.svg" alt="Vercel Logo" width={72} height={16} />
-          </span>
-        </a>
-      </footer>
     </div>
   )
 }

--- a/demos/middleware/pages/shows/rewriteme/index.js
+++ b/demos/middleware/pages/shows/rewriteme/index.js
@@ -1,0 +1,9 @@
+const Show = () => {
+  return (
+    <div>
+      <p>This should have been rewritten</p>
+    </div>
+  )
+}
+
+export default Show

--- a/plugin/src/templates/edge/utils.ts
+++ b/plugin/src/templates/edge/utils.ts
@@ -33,11 +33,9 @@ export const buildResponse = async ({
   request.headers.set('x-nf-next-middleware', 'skip')
   const rewrite = res.headers.get('x-middleware-rewrite')
   if (rewrite) {
-    res.headers.delete('x-middleware-rewrite')
     return addMiddlewareHeaders(context.rewrite(rewrite), res)
   }
   if (res.headers.get('x-middleware-next') === '1') {
-    res.headers.delete('x-middleware-next')
     return addMiddlewareHeaders(context.next(), res)
   }
   return res


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Currently our middleware edge function wrapper strips any internal Next headers before returning them to the client. This is a mistake, because Next uses these headers during navigation. This PR adds them back in.

### Test plan

1. Visit the middleware deploy preview, https://deploy-preview-1322--next-plugin-edge-middleware.netlify.app/
2. Click the _Rewrite me_ link on the homepage
3. Ensure it's rewritten to a show the page at https://deploy-preview-1322--next-plugin-edge-middleware.netlify.app/shows/100

![CleanShot 2022-04-22 at 13 12 56](https://user-images.githubusercontent.com/833231/164762601-030e1fa3-2f0c-45ff-a000-d890a359891d.png)


### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes #1321 

![capybara and anteater](https://pbs.twimg.com/media/FQ4w9r5XIAIeJ_D?format=jpg&name=small)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
