### PR TITLE
fix: handle absolute rewrite URLs

### DIFF
--- a/demos/middleware/pages/index.js
+++ b/demos/middleware/pages/index.js
@@ -16,7 +16,9 @@ export default function Home() {
           Welcome to <a href="https://nextjs.org">Next.js!</a>
         </h1>
 
-        <p><Link href="/shows/rewriteme">Rewrite me</Link></p>
+        <p><Link href="/shows/rewriteme">Rewrite URL</Link></p>
+        <p><Link href="/shows/rewrite-absolute">Rewrite to absolute URL</Link></p>
+        <p><Link href="/shows/rewrite-external">Rewrite to external URL</Link></p>
       </main>
     </div>
   )

--- a/demos/middleware/pages/shows/rewrite-absolute/_middleware.ts
+++ b/demos/middleware/pages/shows/rewrite-absolute/_middleware.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { NextFetchEvent, NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest, ev: NextFetchEvent) {
+  const res = NextResponse.rewrite(new URL('/shows/100', req.url))
+  res.headers.set('x-modified-in-rewrite', 'true')
+  return res
+}

--- a/demos/middleware/pages/shows/rewrite-absolute/index.js
+++ b/demos/middleware/pages/shows/rewrite-absolute/index.js
@@ -1,0 +1,9 @@
+const Show = () => {
+  return (
+    <div>
+      <p>This should have been rewritten</p>
+    </div>
+  )
+}
+
+export default Show

--- a/demos/middleware/pages/shows/rewrite-external/_middleware.ts
+++ b/demos/middleware/pages/shows/rewrite-external/_middleware.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server'
+import { NextFetchEvent, NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest, ev: NextFetchEvent) {
+  const res = NextResponse.rewrite('http://example.com/')
+  res.headers.set('x-modified-in-rewrite', 'true')
+  return res
+}

--- a/demos/middleware/pages/shows/rewrite-external/index.js
+++ b/demos/middleware/pages/shows/rewrite-external/index.js
@@ -1,0 +1,9 @@
+const Show = () => {
+  return (
+    <div>
+      <p>This should have been rewritten</p>
+    </div>
+  )
+}
+
+export default Show

--- a/plugin/src/templates/edge/utils.ts
+++ b/plugin/src/templates/edge/utils.ts
@@ -5,6 +5,19 @@ export interface FetchEventResult {
   waitUntil: Promise<any>
 }
 
+/**
+ * This is how Next handles rewritten URLs.
+ */
+ export function relativizeURL(url: string | string, base: string | URL) {
+  const baseURL = typeof base === 'string' ? new URL(base) : base
+  const relative = new URL(url, base)
+  const origin = `${baseURL.protocol}//${baseURL.host}`
+  return `${relative.protocol}//${relative.host}` === origin
+    ? relative.toString().replace(origin, '')
+    : relative.toString()
+}
+
+
 export const addMiddlewareHeaders = async (
   originResponse: Promise<Response> | Response,
   middlewareResponse: Response,
@@ -33,6 +46,7 @@ export const buildResponse = async ({
   request.headers.set('x-nf-next-middleware', 'skip')
   const rewrite = res.headers.get('x-middleware-rewrite')
   if (rewrite) {
+    res.headers.set('x-middleware-rewrite', relativizeURL(rewrite, request.url))
     return addMiddlewareHeaders(context.rewrite(rewrite), res)
   }
   if (res.headers.get('x-middleware-next') === '1') {


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

When rewriting a URL in middleware, it attaches an `x-middleware-rewrite` header with the target URL. This is used both for server-side rewrites, but also for client-side preflights. The returned value can be either a relative or absolute URL. Previously we passed-through the header unchanged. This caused problems for two reasons. First, if it is an absolute URL it is treated as external by the router on the client, even if it is not, which caused Next to get into an infinite reload loop as it tried to redirect to itself. For actual external URLs it was failing because Netlify Edge Functions don't support rewriting to external URLs.

This fixes these problems in two parts:

- If the absolute URL is actually local then it makes it into a relative URL using [the same algorithm as Next.js](https://github.com/vercel/next.js/blob/canary/packages/next/shared/lib/router/utils/relativize-url.ts#L6)
- If the URL is external, then instead of using `context.rewrite()` it instead calls `fetch()`, adds the appropriate headers to the response, and returns the response. 

### Test plan

1. Visit [the middleware deploy preview](https://deploy-preview-1325--next-plugin-edge-middleware.netlify.app/)
2. View the absolute URL demo. Check that the page loads correctly and that the `x-middleware-rewrite` headers is relative
3. Visit the external URL demo. Check that it returns the proxied content of "example.com". Check that the `x-middleware-rewrite` header is "http://example.com".

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

Fixes issue mentioned in [this comment](https://github.com/netlify/netlify-plugin-nextjs/issues/1321#issuecomment-1109184031)

![black capybara](https://pbs.twimg.com/media/FROQTIeWQAEG7SY?format=jpg&name=small)



### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
