### PR TITLE
fix: specify version of next-auth

### DIFF
--- a/demos/next-auth/package.json
+++ b/demos/next-auth/package.json
@@ -23,7 +23,7 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "next-auth": "latest",
+    "next-auth": "^4.3.3",
     "nodemailer": "^6.6.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"


### PR DESCRIPTION
### Summary

In the demo site for `next-auth`, the `next-auth` dependency was listed as 'latest'. When using the 'latest' tag, v3 of next-auth was being installed rather than v4.

This was causing build errors because the type definitions used in the example project aren't introduced until v4.

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![polar-bear-cub-6](https://user-images.githubusercontent.com/5655473/165341534-c3fc5922-e870-4e06-aaa8-9de35cea76f7.jpg)


### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
