### PR TITLE
chore: rebuild default demo if any changes are made in repo

### DIFF
--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin"
+ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../.."
 
 [build.environment]
 # cache Cypress binary in local "node_modules" folder


### PR DESCRIPTION
### Summary

This change forces rebuilds if there are any changes in the repo - fixing an issue where cypress tests fail on PRs if changes had been made outside of the default demo, or the plugin directory, as Netlify builds would be cancelled.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
<img width="255" alt="Screen Shot 2022-04-28 at 11 20 28 AM" src="https://user-images.githubusercontent.com/4700602/165786875-786c8b0c-0be5-435b-9990-8ef308ab9465.png">

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
