### PR TITLE
feat: Include basePath property in NEXTAUTH_URL when present in config

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -79,7 +79,7 @@ const plugin: NetlifyPlugin = {
       console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${process.env.URL}`)
 
       const config = await getRequiredServerFiles(publish)
-      const nextAuthUrl = `${process.env.URL}${basePath}`;
+      const nextAuthUrl = `${process.env.URL}${basePath}`
       config.config.env.NEXTAUTH_URL = nextAuthUrl
 
       await updateRequiredServerFiles(publish, config)

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -79,7 +79,8 @@ const plugin: NetlifyPlugin = {
       console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${process.env.URL}`)
 
       const config = await getRequiredServerFiles(publish)
-      config.config.env.NEXTAUTH_URL = process.env.URL
+      const nextAuthUrl = `${process.env.URL}${basePath}`;
+      config.config.env.NEXTAUTH_URL = nextAuthUrl
 
       await updateRequiredServerFiles(publish, config)
     }


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

This was missed in the initial implementation of adding out of the box NextAuth support (see #1242 ), but is something that is needed when the `basePath` property exists within the `next.config.js` file. Related docs on NextAuth can be found [here](https://next-auth.js.org/configuration/options#nextauth_url)

### Test plan

1. Visit the Deploy Preview [here](https://deploy-preview-1336--netlify-plugin-nextjs-next-auth-demo.netlify.app/)

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![trash_panda](https://user-images.githubusercontent.com/5655473/166252550-25dade36-1307-42cf-b342-d333e1e99c43.jpg)


### Standard checks:

- [ ] Check the Deploy Preview's Demo site for your PR's functionality

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
