### PR TITLE
fix: don't override user defined NEXTAUTH_URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@types/node": "^17.0.10",
         "@types/react": "^17.0.38",
         "babel-jest": "^27.2.5",
+        "chance": "^1.1.8",
         "cpy": "^8.1.2",
         "cypress": "^9.0.0",
         "eslint-config-next": "^12.0.0",
@@ -7711,6 +7712,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/chance": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.8.tgz",
+      "integrity": "sha512-v7fi5Hj2VbR6dJEGRWLmJBA83LJMS47pkAbmROFxHWd9qmE1esHRZW8Clf1Fhzr3rjxnNZVCjOEv/ivFxeIMtg==",
+      "dev": true
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -29353,6 +29360,12 @@
           }
         }
       }
+    },
+    "chance": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/chance/-/chance-1.1.8.tgz",
+      "integrity": "sha512-v7fi5Hj2VbR6dJEGRWLmJBA83LJMS47pkAbmROFxHWd9qmE1esHRZW8Clf1Fhzr3rjxnNZVCjOEv/ivFxeIMtg==",
+      "dev": true
     },
     "char-regex": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^17.0.10",
     "@types/react": "^17.0.38",
     "babel-jest": "^27.2.5",
+    "chance": "^1.1.8",
     "cpy": "^8.1.2",
     "cypress": "^9.0.0",
     "eslint-config-next": "^12.0.0",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -76,13 +76,22 @@ const plugin: NetlifyPlugin = {
     })
 
     if (isNextAuthInstalled()) {
-      console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${process.env.URL}`)
-
       const config = await getRequiredServerFiles(publish)
-      const nextAuthUrl = `${process.env.URL}${basePath}`
-      config.config.env.NEXTAUTH_URL = nextAuthUrl
 
-      await updateRequiredServerFiles(publish, config)
+      const userDefinedNextAuthUrl = config.config.env.NEXTAUTH_URL
+
+      if (userDefinedNextAuthUrl) {
+        console.log(
+          `NextAuth package detected, NEXTAUTH_URL environment variable set by user to ${userDefinedNextAuthUrl}`,
+        )
+      } else {
+        console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${process.env.URL}`)
+
+        const nextAuthUrl = `${process.env.URL}${basePath}`
+        config.config.env.NEXTAUTH_URL = nextAuthUrl
+
+        await updateRequiredServerFiles(publish, config)
+      }
     }
 
     const buildId = readFileSync(join(publish, 'BUILD_ID'), 'utf8').trim()

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -85,9 +85,9 @@ const plugin: NetlifyPlugin = {
           `NextAuth package detected, NEXTAUTH_URL environment variable set by user to ${userDefinedNextAuthUrl}`,
         )
       } else {
-        console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${process.env.URL}`)
-
         const nextAuthUrl = `${process.env.URL}${basePath}`
+
+        console.log(`NextAuth package detected, setting NEXTAUTH_URL environment variable to ${nextAuthUrl}`)
         config.config.env.NEXTAUTH_URL = nextAuthUrl
 
         await updateRequiredServerFiles(publish, config)

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ jest.mock('../plugin/src/helpers/utils', () => {
   }
 })
 
+const Chance = require('chance')
 const { writeJSON, unlink, existsSync, readFileSync, copy, ensureDir, readJson } = require('fs-extra')
 const path = require('path')
 const process = require('process')
@@ -29,6 +30,7 @@ const { getRequiredServerFiles, updateRequiredServerFiles } = require('../plugin
 const { dirname } = require('path')
 const { getProblematicUserRewrites } = require('../plugin/src/helpers/verification')
 
+const chance = new Chance()
 const FIXTURES_DIR = `${__dirname}/fixtures`
 const SAMPLE_PROJECT_DIR = `${__dirname}/../demos/default`
 const constants = {
@@ -221,8 +223,27 @@ describe('onBuild()', () => {
     })
   })
 
+  test('does not set NEXTAUTH_URL if value is already set', async () => {
+    const mockUserDefinedSiteUrl = chance.url()
+    process.env.URL = chance.url()
+
+    await moveNextDist()
+    
+    const initialConfig = await getRequiredServerFiles(netlifyConfig.build.publish)
+    
+    initialConfig.config.env.NEXTAUTH_URL = mockUserDefinedSiteUrl
+    await updateRequiredServerFiles(netlifyConfig.build.publish, initialConfig)
+
+    await plugin.onBuild(defaultArgs)
+
+    expect(onBuildHasRun(netlifyConfig)).toBe(true)
+    const config = await getRequiredServerFiles(netlifyConfig.build.publish)
+
+    expect(config.config.env.NEXTAUTH_URL).toEqual(mockUserDefinedSiteUrl)
+  })
+
   test('sets NEXTAUTH_URL when next-auth package is detected', async () => {
-    const mockSiteUrl = 'https://my-netlify-site.app'
+    const mockSiteUrl = chance.url()
 
     // Value represents the main address to the site and is either
     // a Netlify subdomain or custom domain set by the user.
@@ -242,7 +263,7 @@ describe('onBuild()', () => {
   })
 
   test('includes the basePath on NEXTAUTH_URL when present', async () => {
-    const mockSiteUrl = 'https://my-netlify-site.app'
+    const mockSiteUrl = chance.url()
     process.env.URL = mockSiteUrl
 
     await moveNextDist()

--- a/test/index.js
+++ b/test/index.js
@@ -223,6 +223,10 @@ describe('onBuild()', () => {
     })
   })
 
+  afterEach(() => {
+    delete process.env.URL
+  })
+
   test('does not set NEXTAUTH_URL if value is already set', async () => {
     const mockUserDefinedSiteUrl = chance.url()
     process.env.URL = chance.url()
@@ -258,8 +262,6 @@ describe('onBuild()', () => {
     const config = await getRequiredServerFiles(netlifyConfig.build.publish)
 
     expect(config.config.env.NEXTAUTH_URL).toEqual(mockSiteUrl)
-
-    delete process.env.URL
   })
 
   test('includes the basePath on NEXTAUTH_URL when present', async () => {
@@ -278,8 +280,6 @@ describe('onBuild()', () => {
     const config = await getRequiredServerFiles(netlifyConfig.build.publish)
 
     expect(config.config.env.NEXTAUTH_URL).toEqual(`${mockSiteUrl}/foo`)
-
-    delete process.env.URL
   })
 
   test('skips setting NEXTAUTH_URL when next-auth package is not found', async () => {


### PR DESCRIPTION
### Summary
As outlined in the issue linked below, a user could have defined `NEXTAUTH_URL` in the `next.config.js` file and ,prior to these changes, the plugin would override the value to set it to what `process.env.URL` is.

These changes check to see if a `NEXTAUTH_URL` already exists within the generated server files after building the site and will continue on if it exists, or generate a default value if one doesn't. 

Logging was added for the scenario where a user defined `NEXTAUTH_URL` exists in order to make it clear about what the plugin is seeing with respect to the `next-auth` related configuration.

These changes also add the `chance` package for unit tests so we can avoid hard coding test values where possible.

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Fixes #1345 

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
