### PR TITLE
chore: add codeowners and fixing pull request template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @netlify/frameworks

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->
+<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->
 
 ### Summary
 


### PR DESCRIPTION
### Summary

Adds @netlify/frameworks as codeowner, and changes the pull request template to mention frameworks instead of integrations
