### PR TITLE
ci: build demos whenever plugin changes or cache cleared

### DIFF
--- a/demos/base-path/netlify.toml
+++ b/demos/base-path/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 # cache Cypress binary in local "node_modules" folder

--- a/demos/default/netlify.toml
+++ b/demos/default/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../.."
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 # cache Cypress binary in local "node_modules" folder

--- a/demos/middleware/netlify.toml
+++ b/demos/middleware/netlify.toml
@@ -1,6 +1,7 @@
 [build]
 command = "npm run build"
 publish = ".next"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 NEXT_USE_NETLIFY_EDGE = "true"

--- a/demos/next-auth/netlify.toml
+++ b/demos/next-auth/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 TERM = "xterm"

--- a/demos/next-export/netlify.toml
+++ b/demos/next-export/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build && next export"
 publish = "out"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 NETLIFY_NEXT_PLUGIN_SKIP = "true"

--- a/demos/next-i18next/netlify.toml
+++ b/demos/next-i18next/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 TERM = "xterm"

--- a/demos/nx-next-monorepo-demo/netlify.toml
+++ b/demos/nx-next-monorepo-demo/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "npm run build"
 publish = "dist/apps/demo-monorepo/.next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [dev]
 command = "npm run start"

--- a/demos/server-components/netlify.toml
+++ b/demos/server-components/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "npm run build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../.."
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 NEXT_USE_NETLIFY_EDGE = "true"

--- a/demos/static-root/netlify.toml
+++ b/demos/static-root/netlify.toml
@@ -1,7 +1,7 @@
 [build]
 command = "next build"
 publish = ".next"
-ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF ../../"
+ignore = "if [ $CACHED_COMMIT_REF == $COMMIT_REF ]; then (exit 1); else git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../../plugin; fi;"
 
 [build.environment]
 # cache Cypress binary in local "node_modules" folder


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Updates the demos' `ignore` commands so that the sites will all build if the plugin changes. It is different from before because it also will now build if the two commit hashes are the same. This is the case when the cache is cleared. Previously this would return a value of unchanged, meaning it wasn't possibel to manually build the demo sites.

### Test plan

1. Check that the sites build

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![capybara](https://pbs.twimg.com/media/FU2kUc5WIAo2MJK?format=jpg&name=small)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
