### PR TITLE
fix: run edge middleware on data requests

### DIFF
--- a/demos/middleware/middleware.ts
+++ b/demos/middleware/middleware.ts
@@ -3,7 +3,9 @@ import { NextFetchEvent, NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest, ev: NextFetchEvent) {
   let response
-  const {nextUrl: {pathname}} = request
+  const {
+    nextUrl: { pathname },
+  } = request
 
   if (pathname.startsWith('/cookies')) {
     response = NextResponse.next()
@@ -30,10 +32,14 @@ export function middleware(request: NextRequest, ev: NextFetchEvent) {
     if (!response) {
       response = NextResponse.next()
     }
+
+    if (pathname.startsWith('/shows/static')) {
+      response.headers.set('x-middleware-date', new Date().toISOString())
+    }
+
     response.headers.set('x-modified-edge', 'true')
     response.headers.set('x-is-deno', 'Deno' in globalThis ? 'true' : 'false')
 
     return response
   }
-
 }

--- a/demos/middleware/package.json
+++ b/demos/middleware/package.json
@@ -9,7 +9,7 @@
     "ntl": "ntl-internal"
   },
   "dependencies": {
-    "next": "^12.1.7-canary.12",
+    "next": "^12.1.7-canary.33",
     "react": "18.0.0",
     "react-dom": "18.0.0"
   },

--- a/demos/middleware/pages/index.js
+++ b/demos/middleware/pages/index.js
@@ -26,6 +26,9 @@ export default function Home() {
           <Link href="/shows/rewrite-external">Rewrite to external URL</Link>
         </p>
         <p>
+          <Link href="/shows/static/3">Add header to static page</Link>
+        </p>
+        <p>
           <Link href="/cookies" prefetch={false}>
             Cookie API
           </Link>

--- a/demos/middleware/pages/shows/static/[id].js
+++ b/demos/middleware/pages/shows/static/[id].js
@@ -1,0 +1,55 @@
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+
+const Show = ({ show }) => {
+  const router = useRouter()
+
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
+
+  return (
+    <div>
+      <p>
+        Check the network panel for the header <code>x-middleware-date</code> to ensure that it is running
+      </p>
+      <hr />
+      <p>
+        <Link href="/shows/static/3">Show 3</Link> and <Link href="/shows/static/4">show 4</Link> are pre-rendered
+      </p>
+      <h1>Show #{show.id}</h1>
+      <p>{show.name}</p>
+
+      <hr />
+
+      <Link href="/">
+        <a>Go back home</a>
+      </Link>
+    </div>
+  )
+}
+
+export async function getStaticPaths() {
+  // Set the paths we want to pre-render
+  const paths = [{ params: { id: '3' } }, { params: { id: '4' } }]
+
+  // We'll pre-render these paths at build time.
+  // { fallback: true } means other routes will be rendered at runtime.
+  return { paths, fallback: true }
+}
+
+export async function getStaticProps({ params }) {
+  // The ID to render
+  const { id } = params
+
+  const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
+  const data = await res.json()
+
+  return {
+    props: {
+      show: data,
+    },
+  }
+}
+
+export default Show

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,7 +149,7 @@
     "demos/middleware": {
       "version": "0.1.0",
       "dependencies": {
-        "next": "^12.1.7-canary.12",
+        "next": "^12.1.7-canary.33",
         "react": "18.0.0",
         "react-dom": "18.0.0"
       },
@@ -165,14 +165,14 @@
       }
     },
     "demos/middleware/node_modules/@next/env": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.7-canary.16.tgz",
-      "integrity": "sha512-AXQXBrXMpf2KqqTcvXvvpJY+qG9tMyAMWyzXrkb02efbufSxeVskY4Y2EACyfarPC95+IycgDFrs8BCDRBDOBA=="
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.7-canary.33.tgz",
+      "integrity": "sha512-eQYNJ1/4cQovdyQZUQ7FdtxmMI+fi8wa+rlH5AXKdmo9BhuRX/K53XDGVqePjR552wz4vZjzOP+tTjX/mVkPXw=="
     },
     "demos/middleware/node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.16.tgz",
-      "integrity": "sha512-ywssG0j6Uld9I9l+7Yapd0chncxTOqowALHEije+Q1CfRbZwOfGlAXctz4jkgfqw5A20i0ETvXA3HeauDKHNQg==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.33.tgz",
+      "integrity": "sha512-p9853r+DRuJS/Vmny0dtKerAG3z7vaP5p3Y3TJNNKh+ugtirDECTnFNiI2SqeHfQfSHA8G8i6u9B8dpoRuAUQQ==",
       "cpu": [
         "arm"
       ],
@@ -185,9 +185,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-android-arm64": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.16.tgz",
-      "integrity": "sha512-qfB6M/SyfxabD+UshiAGzwB3qBDHljgLfAcxoir5UWjVdGk7zp2zFcL93MEz/o1gc2QLjk0CTppTURXq2bVdoQ==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.33.tgz",
+      "integrity": "sha512-698CGAB5+LgEjTguycCFvUl1oR2HegAQh3PQlLFtJPqdNUb7eR/hviBIJJTki173Rv3OGqWRCzG8Toyu88DtKA==",
       "cpu": [
         "arm64"
       ],
@@ -200,9 +200,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-darwin-arm64": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.16.tgz",
-      "integrity": "sha512-m2xRcT6Vc9g7GWJB1wEEg/AYnf1dlEXYKb8SVsY82BTF2zxgQCfFDVwSZSF8VxgQA670itTBNq3kk6geq1X41A==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.33.tgz",
+      "integrity": "sha512-Hv5U6ZREmyomzEjy6Efr3pTAlgxFv7Kfa53FPFT1W/zPQDu5wo664qBiM8nxThbNarr3/w6zCJV+pm5gDFLsgQ==",
       "cpu": [
         "arm64"
       ],
@@ -215,9 +215,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-darwin-x64": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.16.tgz",
-      "integrity": "sha512-X95zXPegmiEeoeF00Vz7AYAmI3AoofenrmZ1TU+huAj0JrpZ7QKG4LrKPZbtiDIhmR6kSuEdtDvlMw15kaA0lg==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.33.tgz",
+      "integrity": "sha512-JYgkL2JrI6GlxHbmsLg9EF++gBi4GoeDv9lG46ImtrwmIJl1vaaQGa8aiSOrz4eLlBF6stlPOkSiILPkBrfQtA==",
       "cpu": [
         "x64"
       ],
@@ -230,9 +230,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.16.tgz",
-      "integrity": "sha512-66jnwNJC+jESiiO6ReUV046u77XYK1nnpf4n71IAqKl5H5KF/QlO7PV+KNMl0UNhILN6RpF6K87lbM+Hq4Ygjw==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.33.tgz",
+      "integrity": "sha512-nYEelsKxVFY7Y59BcSnl7Tkf+RGzmPxVPySZXtdXHJPFVaKpoQNR0K5QG595UYBp4QWUwjGE2RqLDVKcNDBW+w==",
       "cpu": [
         "arm"
       ],
@@ -245,9 +245,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.16.tgz",
-      "integrity": "sha512-Uj9tSd6rK+fuql8lDcmGZmPh6O/6Ld5xNIZH0gRGYHC/tNUTOPgTxo9Fixebkc1ELWBIspxNINx557OGgceltg==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.33.tgz",
+      "integrity": "sha512-SfPq5JCj2IIct6R5tP7UGshMdNFK0oexShAXWYGdbbP+OOtu8dH9IL0uJOxGprwE9XTMICHUt1uVUWH4nHn8eQ==",
       "cpu": [
         "arm64"
       ],
@@ -260,9 +260,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.16.tgz",
-      "integrity": "sha512-hhGkJRuSO/ML6Kvne9H2EMY6VdmR/39ZJXoH6IOG7t6qRGSmW3q0Nhhdfdz6lT2a7EhggMd81La76UOkx0ZuAQ==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.33.tgz",
+      "integrity": "sha512-BBH+d18x600OiFf0uIY7n5HryXmKpbCTCXheCYr5vLalX7KdRRlyXJk8L3zWT0xnHJZLrW24xkW2lPblQMFa+w==",
       "cpu": [
         "arm64"
       ],
@@ -275,9 +275,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.16.tgz",
-      "integrity": "sha512-8oB8WEVtWc6PPEzwA6sqiVyZ/hz/MZnoG9Thsg2mNMKCbF2C1xrObsMvGl61vMTvjxQDOguDoJFY57AUlorHcQ==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.33.tgz",
+      "integrity": "sha512-BdRIwzq6n0LdpalLweXPVkNG0gf4LiVGCnKzYorWaMOp7g2U9kQJzAOAr8Ss695n32oXWSMvAVdfrxklhW7qFQ==",
       "cpu": [
         "x64"
       ],
@@ -290,9 +290,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.16.tgz",
-      "integrity": "sha512-fw2DD9yApjdfbaMUDyRx8yrdJvQurrmqyxhSBHse7lo929eIRkPl6N1/PpDenPn4spftv9uZ5qYguOmvCRU3FQ==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.33.tgz",
+      "integrity": "sha512-qOi4/ewAkHzluLc2nNmxtgdzZw7Arlk78j3gK1K6VD2mPJ0XJGNeDra6dGoc0YfWDF66qqieZyNN1Mad0qVW5Q==",
       "cpu": [
         "x64"
       ],
@@ -305,9 +305,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.16.tgz",
-      "integrity": "sha512-D3YxibVZRymUg4N1gi5zdLsaLPz/wllDy/jj5umip7PBgtdevDRncaxLOzK6i8uvHUzziqeW9pToXVycB2BNyw==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.33.tgz",
+      "integrity": "sha512-G9bMfMa4zEB99clJZqSR2vLHGxz4ScbK4Ioeob9sJbImRF4YtAtMOTyMGpVGsildA5C71Y+khikYLJkSuvljmw==",
       "cpu": [
         "arm64"
       ],
@@ -320,9 +320,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.16.tgz",
-      "integrity": "sha512-q3oskcJXPxF+nk9g1IDiEupYgM/i0ssYU6q37jxBy2kjucO6/2rKwNw5M9xQ/cLwzPlnrf4gPvEN7ZhND1Lzrg==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.33.tgz",
+      "integrity": "sha512-clKMh9tTCmnRzXcBjB4H1RWxwMdKVfD1uTv8KdOSQXP+G/tmDGVAX1zNQXkj+R5lltfvunejSLfsT75CZ3xsMA==",
       "cpu": [
         "ia32"
       ],
@@ -335,9 +335,9 @@
       }
     },
     "demos/middleware/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.16.tgz",
-      "integrity": "sha512-FnWqfBS1WE+rj+91uap2EzafSBXJsP0AYWBG7a9DfACJnnIQwbVZVL5qOV/y6ZICrWClhLPSU4dNEFPqAlPNUQ==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.33.tgz",
+      "integrity": "sha512-lcC15gBcRfmMC7eahUmjESsU/PUQv6PL2HmTVIOM7DP88U+Ma6AYebhpcrE8W26tpOXgRph/x9CMeB33spS60g==",
       "cpu": [
         "x64"
       ],
@@ -350,11 +350,12 @@
       }
     },
     "demos/middleware/node_modules/next": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.1.7-canary.16.tgz",
-      "integrity": "sha512-8Zf4I7a/leSXxjlNyXJN6EYfYxcdasMfDaMtl6FHaBSeWkShhn1OxD1iFb90V6kYMDfHpeYaYUW/hLBfOtmI2A==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/next/-/next-12.1.7-canary.33.tgz",
+      "integrity": "sha512-GG+ORfIrtsWPFRaxrXnzKdyom392JIndFfDJNWNMgQ52UXiXo3jtvnjSgI28+9i2WuKglicDCTeNikbQQ4lO0g==",
       "dependencies": {
-        "@next/env": "12.1.7-canary.16",
+        "@next/env": "12.1.7-canary.33",
+        "@swc/helpers": "0.3.17",
         "caniuse-lite": "^1.0.30001332",
         "postcss": "8.4.5",
         "styled-jsx": "5.0.2",
@@ -367,19 +368,19 @@
         "node": ">=12.22.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.1.7-canary.16",
-        "@next/swc-android-arm64": "12.1.7-canary.16",
-        "@next/swc-darwin-arm64": "12.1.7-canary.16",
-        "@next/swc-darwin-x64": "12.1.7-canary.16",
-        "@next/swc-freebsd-x64": "12.1.7-canary.16",
-        "@next/swc-linux-arm-gnueabihf": "12.1.7-canary.16",
-        "@next/swc-linux-arm64-gnu": "12.1.7-canary.16",
-        "@next/swc-linux-arm64-musl": "12.1.7-canary.16",
-        "@next/swc-linux-x64-gnu": "12.1.7-canary.16",
-        "@next/swc-linux-x64-musl": "12.1.7-canary.16",
-        "@next/swc-win32-arm64-msvc": "12.1.7-canary.16",
-        "@next/swc-win32-ia32-msvc": "12.1.7-canary.16",
-        "@next/swc-win32-x64-msvc": "12.1.7-canary.16"
+        "@next/swc-android-arm-eabi": "12.1.7-canary.33",
+        "@next/swc-android-arm64": "12.1.7-canary.33",
+        "@next/swc-darwin-arm64": "12.1.7-canary.33",
+        "@next/swc-darwin-x64": "12.1.7-canary.33",
+        "@next/swc-freebsd-x64": "12.1.7-canary.33",
+        "@next/swc-linux-arm-gnueabihf": "12.1.7-canary.33",
+        "@next/swc-linux-arm64-gnu": "12.1.7-canary.33",
+        "@next/swc-linux-arm64-musl": "12.1.7-canary.33",
+        "@next/swc-linux-x64-gnu": "12.1.7-canary.33",
+        "@next/swc-linux-x64-musl": "12.1.7-canary.33",
+        "@next/swc-win32-arm64-msvc": "12.1.7-canary.33",
+        "@next/swc-win32-ia32-msvc": "12.1.7-canary.33",
+        "@next/swc-win32-x64-msvc": "12.1.7-canary.33"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
@@ -5393,9 +5394,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.16.tgz",
-      "integrity": "sha512-yH/72tv8qZVLXB5OOUzo4OZCpwg7IoXot6Vd6Lck/niMbn+EgC8Nb27TZGOZVyPaNjwxqchMPR0nYmvsQke/0A==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.33.tgz",
+      "integrity": "sha512-ltFPOaWCw8w84nAieKN6PpYw5xrD8m1rtMGdZ2uXmHqWc6LnGpbs6XBcnl20+gIwuTmCmHg3ZNTgoe+BzmozEw==",
       "cpu": [
         "x64"
       ],
@@ -5633,6 +5634,14 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -5925,13 +5934,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
       "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5951,7 +5960,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -9477,7 +9486,7 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/cypress": {
       "version": "9.5.4",
@@ -13667,7 +13676,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
       "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -21156,7 +21165,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
       "integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -22947,9 +22956,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsscmp": {
       "version": "1.0.6",
@@ -27633,9 +27642,9 @@
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "12.1.7-canary.16",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.16.tgz",
-      "integrity": "sha512-yH/72tv8qZVLXB5OOUzo4OZCpwg7IoXot6Vd6Lck/niMbn+EgC8Nb27TZGOZVyPaNjwxqchMPR0nYmvsQke/0A==",
+      "version": "12.1.7-canary.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.1.7-canary.33.tgz",
+      "integrity": "sha512-ltFPOaWCw8w84nAieKN6PpYw5xrD8m1rtMGdZ2uXmHqWc6LnGpbs6XBcnl20+gIwuTmCmHg3ZNTgoe+BzmozEw==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
@@ -27765,6 +27774,14 @@
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@swc/helpers": {
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
+      "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
+      "requires": {
+        "tslib": "^2.4.0"
       }
     },
     "@szmarczak/http-timer": {
@@ -28041,13 +28058,13 @@
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
       "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "devOptional": true
+      "dev": true
     },
     "@types/react": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.45.tgz",
       "integrity": "sha512-YfhQ22Lah2e3CHPsb93tRwIGNiSwkuz1/blk4e6QrWS0jQzCSNbGLtOEYhPg02W0yGTTmpajp7dCTbBAMN3qsg==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28067,7 +28084,7 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
-      "devOptional": true
+      "dev": true
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -28375,8 +28392,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -30708,7 +30724,7 @@
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz",
       "integrity": "sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==",
-      "devOptional": true
+      "dev": true
     },
     "cypress": {
       "version": "9.5.4",
@@ -31874,15 +31890,13 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
       "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-config-standard": {
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -32337,8 +32351,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-react": {
       "version": "7.29.4",
@@ -32386,8 +32399,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
       "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-unicorn": {
       "version": "40.1.0",
@@ -33877,7 +33889,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0.tgz",
       "integrity": "sha512-zIE9hX70qew5qTUjSS7wi1iwj/l7+m54KWU247nhM3v806UdGj1yDndXj+IOYxxtW9zyLI+xqFNZjTuDaLUqFw==",
-      "devOptional": true
+      "dev": true
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -34953,8 +34965,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -36662,7 +36673,7 @@
         "@types/node": "^17.0.25",
         "@types/react": "^17.0.43",
         "husky": "^7.0.4",
-        "next": "^12.1.7-canary.12",
+        "next": "12.1.7-canary.33",
         "npm-run-all": "^4.1.5",
         "react": "18.0.0",
         "react-dom": "18.0.0",
@@ -36670,101 +36681,102 @@
       },
       "dependencies": {
         "@next/env": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.7-canary.16.tgz",
-          "integrity": "sha512-AXQXBrXMpf2KqqTcvXvvpJY+qG9tMyAMWyzXrkb02efbufSxeVskY4Y2EACyfarPC95+IycgDFrs8BCDRBDOBA=="
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/env/-/env-12.1.7-canary.33.tgz",
+          "integrity": "sha512-eQYNJ1/4cQovdyQZUQ7FdtxmMI+fi8wa+rlH5AXKdmo9BhuRX/K53XDGVqePjR552wz4vZjzOP+tTjX/mVkPXw=="
         },
         "@next/swc-android-arm-eabi": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.16.tgz",
-          "integrity": "sha512-ywssG0j6Uld9I9l+7Yapd0chncxTOqowALHEije+Q1CfRbZwOfGlAXctz4jkgfqw5A20i0ETvXA3HeauDKHNQg==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.1.7-canary.33.tgz",
+          "integrity": "sha512-p9853r+DRuJS/Vmny0dtKerAG3z7vaP5p3Y3TJNNKh+ugtirDECTnFNiI2SqeHfQfSHA8G8i6u9B8dpoRuAUQQ==",
           "optional": true
         },
         "@next/swc-android-arm64": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.16.tgz",
-          "integrity": "sha512-qfB6M/SyfxabD+UshiAGzwB3qBDHljgLfAcxoir5UWjVdGk7zp2zFcL93MEz/o1gc2QLjk0CTppTURXq2bVdoQ==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.1.7-canary.33.tgz",
+          "integrity": "sha512-698CGAB5+LgEjTguycCFvUl1oR2HegAQh3PQlLFtJPqdNUb7eR/hviBIJJTki173Rv3OGqWRCzG8Toyu88DtKA==",
           "optional": true
         },
         "@next/swc-darwin-arm64": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.16.tgz",
-          "integrity": "sha512-m2xRcT6Vc9g7GWJB1wEEg/AYnf1dlEXYKb8SVsY82BTF2zxgQCfFDVwSZSF8VxgQA670itTBNq3kk6geq1X41A==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.1.7-canary.33.tgz",
+          "integrity": "sha512-Hv5U6ZREmyomzEjy6Efr3pTAlgxFv7Kfa53FPFT1W/zPQDu5wo664qBiM8nxThbNarr3/w6zCJV+pm5gDFLsgQ==",
           "optional": true
         },
         "@next/swc-darwin-x64": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.16.tgz",
-          "integrity": "sha512-X95zXPegmiEeoeF00Vz7AYAmI3AoofenrmZ1TU+huAj0JrpZ7QKG4LrKPZbtiDIhmR6kSuEdtDvlMw15kaA0lg==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.7-canary.33.tgz",
+          "integrity": "sha512-JYgkL2JrI6GlxHbmsLg9EF++gBi4GoeDv9lG46ImtrwmIJl1vaaQGa8aiSOrz4eLlBF6stlPOkSiILPkBrfQtA==",
           "optional": true
         },
         "@next/swc-linux-arm-gnueabihf": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.16.tgz",
-          "integrity": "sha512-66jnwNJC+jESiiO6ReUV046u77XYK1nnpf4n71IAqKl5H5KF/QlO7PV+KNMl0UNhILN6RpF6K87lbM+Hq4Ygjw==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.1.7-canary.33.tgz",
+          "integrity": "sha512-nYEelsKxVFY7Y59BcSnl7Tkf+RGzmPxVPySZXtdXHJPFVaKpoQNR0K5QG595UYBp4QWUwjGE2RqLDVKcNDBW+w==",
           "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.16.tgz",
-          "integrity": "sha512-Uj9tSd6rK+fuql8lDcmGZmPh6O/6Ld5xNIZH0gRGYHC/tNUTOPgTxo9Fixebkc1ELWBIspxNINx557OGgceltg==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.1.7-canary.33.tgz",
+          "integrity": "sha512-SfPq5JCj2IIct6R5tP7UGshMdNFK0oexShAXWYGdbbP+OOtu8dH9IL0uJOxGprwE9XTMICHUt1uVUWH4nHn8eQ==",
           "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.16.tgz",
-          "integrity": "sha512-hhGkJRuSO/ML6Kvne9H2EMY6VdmR/39ZJXoH6IOG7t6qRGSmW3q0Nhhdfdz6lT2a7EhggMd81La76UOkx0ZuAQ==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.1.7-canary.33.tgz",
+          "integrity": "sha512-BBH+d18x600OiFf0uIY7n5HryXmKpbCTCXheCYr5vLalX7KdRRlyXJk8L3zWT0xnHJZLrW24xkW2lPblQMFa+w==",
           "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.16.tgz",
-          "integrity": "sha512-8oB8WEVtWc6PPEzwA6sqiVyZ/hz/MZnoG9Thsg2mNMKCbF2C1xrObsMvGl61vMTvjxQDOguDoJFY57AUlorHcQ==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.1.7-canary.33.tgz",
+          "integrity": "sha512-BdRIwzq6n0LdpalLweXPVkNG0gf4LiVGCnKzYorWaMOp7g2U9kQJzAOAr8Ss695n32oXWSMvAVdfrxklhW7qFQ==",
           "optional": true
         },
         "@next/swc-linux-x64-musl": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.16.tgz",
-          "integrity": "sha512-fw2DD9yApjdfbaMUDyRx8yrdJvQurrmqyxhSBHse7lo929eIRkPl6N1/PpDenPn4spftv9uZ5qYguOmvCRU3FQ==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.1.7-canary.33.tgz",
+          "integrity": "sha512-qOi4/ewAkHzluLc2nNmxtgdzZw7Arlk78j3gK1K6VD2mPJ0XJGNeDra6dGoc0YfWDF66qqieZyNN1Mad0qVW5Q==",
           "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.16.tgz",
-          "integrity": "sha512-D3YxibVZRymUg4N1gi5zdLsaLPz/wllDy/jj5umip7PBgtdevDRncaxLOzK6i8uvHUzziqeW9pToXVycB2BNyw==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.1.7-canary.33.tgz",
+          "integrity": "sha512-G9bMfMa4zEB99clJZqSR2vLHGxz4ScbK4Ioeob9sJbImRF4YtAtMOTyMGpVGsildA5C71Y+khikYLJkSuvljmw==",
           "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.16.tgz",
-          "integrity": "sha512-q3oskcJXPxF+nk9g1IDiEupYgM/i0ssYU6q37jxBy2kjucO6/2rKwNw5M9xQ/cLwzPlnrf4gPvEN7ZhND1Lzrg==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.1.7-canary.33.tgz",
+          "integrity": "sha512-clKMh9tTCmnRzXcBjB4H1RWxwMdKVfD1uTv8KdOSQXP+G/tmDGVAX1zNQXkj+R5lltfvunejSLfsT75CZ3xsMA==",
           "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.16.tgz",
-          "integrity": "sha512-FnWqfBS1WE+rj+91uap2EzafSBXJsP0AYWBG7a9DfACJnnIQwbVZVL5qOV/y6ZICrWClhLPSU4dNEFPqAlPNUQ==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.7-canary.33.tgz",
+          "integrity": "sha512-lcC15gBcRfmMC7eahUmjESsU/PUQv6PL2HmTVIOM7DP88U+Ma6AYebhpcrE8W26tpOXgRph/x9CMeB33spS60g==",
           "optional": true
         },
         "next": {
-          "version": "12.1.7-canary.16",
-          "resolved": "https://registry.npmjs.org/next/-/next-12.1.7-canary.16.tgz",
-          "integrity": "sha512-8Zf4I7a/leSXxjlNyXJN6EYfYxcdasMfDaMtl6FHaBSeWkShhn1OxD1iFb90V6kYMDfHpeYaYUW/hLBfOtmI2A==",
+          "version": "12.1.7-canary.33",
+          "resolved": "https://registry.npmjs.org/next/-/next-12.1.7-canary.33.tgz",
+          "integrity": "sha512-GG+ORfIrtsWPFRaxrXnzKdyom392JIndFfDJNWNMgQ52UXiXo3jtvnjSgI28+9i2WuKglicDCTeNikbQQ4lO0g==",
           "requires": {
-            "@next/env": "12.1.7-canary.16",
-            "@next/swc-android-arm-eabi": "12.1.7-canary.16",
-            "@next/swc-android-arm64": "12.1.7-canary.16",
-            "@next/swc-darwin-arm64": "12.1.7-canary.16",
-            "@next/swc-darwin-x64": "12.1.7-canary.16",
-            "@next/swc-freebsd-x64": "12.1.7-canary.16",
-            "@next/swc-linux-arm-gnueabihf": "12.1.7-canary.16",
-            "@next/swc-linux-arm64-gnu": "12.1.7-canary.16",
-            "@next/swc-linux-arm64-musl": "12.1.7-canary.16",
-            "@next/swc-linux-x64-gnu": "12.1.7-canary.16",
-            "@next/swc-linux-x64-musl": "12.1.7-canary.16",
-            "@next/swc-win32-arm64-msvc": "12.1.7-canary.16",
-            "@next/swc-win32-ia32-msvc": "12.1.7-canary.16",
-            "@next/swc-win32-x64-msvc": "12.1.7-canary.16",
+            "@next/env": "12.1.7-canary.33",
+            "@next/swc-android-arm-eabi": "12.1.7-canary.33",
+            "@next/swc-android-arm64": "12.1.7-canary.33",
+            "@next/swc-darwin-arm64": "12.1.7-canary.33",
+            "@next/swc-darwin-x64": "12.1.7-canary.33",
+            "@next/swc-freebsd-x64": "12.1.7-canary.33",
+            "@next/swc-linux-arm-gnueabihf": "12.1.7-canary.33",
+            "@next/swc-linux-arm64-gnu": "12.1.7-canary.33",
+            "@next/swc-linux-arm64-musl": "12.1.7-canary.33",
+            "@next/swc-linux-x64-gnu": "12.1.7-canary.33",
+            "@next/swc-linux-x64-musl": "12.1.7-canary.33",
+            "@next/swc-win32-arm64-msvc": "12.1.7-canary.33",
+            "@next/swc-win32-ia32-msvc": "12.1.7-canary.33",
+            "@next/swc-win32-x64-msvc": "12.1.7-canary.33",
+            "@swc/helpers": "0.3.17",
             "caniuse-lite": "^1.0.30001332",
             "postcss": "8.4.5",
             "styled-jsx": "5.0.2",
@@ -36774,8 +36786,7 @@
             "use-sync-external-store": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.1.0.tgz",
-              "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ==",
-              "requires": {}
+              "integrity": "sha512-SEnieB2FPKEVne66NpXPd1Np4R1lTNKfjuy3XdIoPQKYBAFdzbzSZlSn1KJZUiihQLQC5Znot4SBz1EOTBwQAQ=="
             }
           }
         }
@@ -39698,7 +39709,7 @@
       "version": "1.50.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
       "integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
-      "devOptional": true,
+      "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -40746,8 +40757,7 @@
     "styled-jsx": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.2.tgz",
-      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==",
-      "requires": {}
+      "integrity": "sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ=="
     },
     "supports-color": {
       "version": "9.2.2",
@@ -41230,9 +41240,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tsscmp": {
       "version": "1.0.6",
@@ -41528,8 +41538,7 @@
         "ws": {
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
-          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "requires": {}
+          "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg=="
         }
       }
     },
@@ -42033,8 +42042,7 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/plugin/src/templates/edge/runtime.ts
+++ b/plugin/src/templates/edge/runtime.ts
@@ -34,7 +34,7 @@ export interface RequestData {
 
 const handler = async (req: Request, context: Context) => {
   const url = new URL(req.url)
-  if (url.pathname.startsWith('/_next/')) {
+  if (url.pathname.startsWith('/_next/static/')) {
     return
   }
 


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/integrations as the Reviewer -->

### Summary

Next.js now runs middleware on internal data requests, so this PR updates the edge function to not skip these.

### Test plan

1. Load [the middleware demo](https://deploy-preview-1382--next-plugin-edge-middleware.netlify.app/)
2. Open network panel
3. Mouse over the "add header to static page" link
4. Check if the `3.json` request has an `x-middleware-date` header

When we have e2e canary tests, or it is released in Next then we can add tests for this.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![proud capy](https://pbs.twimg.com/media/FUxxsKuVIAAZNh4?format=jpg&name=large)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
