### PR TITLE
fix: check for existence of experimental images

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24209,7 +24209,7 @@
     },
     "plugin": {
       "name": "@netlify/plugin-nextjs",
-      "version": "4.8.0",
+      "version": "4.9.0",
       "license": "ISC",
       "dependencies": {
         "@netlify/functions": "^1.0.0",

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -72,22 +72,17 @@ const plugin: NetlifyPlugin = {
 
     checkNextSiteHasBuilt({ publish, failBuild })
 
-    const {
-      appDir,
-      basePath,
-      i18n,
-      images,
-      target,
-      ignore,
-      trailingSlash,
-      outdir,
-      experimental: {
-        images: { remotePatterns },
+    let experimentalRemotePatterns = []
+    const { appDir, basePath, i18n, images, target, ignore, trailingSlash, outdir, experimental } = await getNextConfig(
+      {
+        publish,
+        failBuild,
       },
-    } = await getNextConfig({
-      publish,
-      failBuild,
-    })
+    )
+
+    if (experimental.images) {
+      experimentalRemotePatterns = experimental.images.remotePatterns
+    }
 
     if (isNextAuthInstalled()) {
       const config = await getRequiredServerFiles(publish)
@@ -128,7 +123,13 @@ const plugin: NetlifyPlugin = {
       nextConfig: { basePath, i18n },
     })
 
-    await setupImageFunction({ constants, imageconfig: images, netlifyConfig, basePath, remotePatterns })
+    await setupImageFunction({
+      constants,
+      imageconfig: images,
+      netlifyConfig,
+      basePath,
+      remotePatterns: experimentalRemotePatterns,
+    })
 
     await generateRedirects({
       netlifyConfig,

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -81,7 +81,7 @@ const plugin: NetlifyPlugin = {
     )
 
     if (experimental.images) {
-      experimentalRemotePatterns = experimental.images.remotePatterns
+      experimentalRemotePatterns = experimental.images.remotePatterns || []
     }
 
     if (isNextAuthInstalled()) {


### PR DESCRIPTION
### Summary

Fixes error if next does not add an `images` object to `experimental`.

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
