### PR TITLE
chore: Revert "chore(deps): update dependency @netlify/build to ^27.1.3 (#1354)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/preset-env": "^7.15.8",
         "@babel/preset-typescript": "^7.16.0",
         "@delucis/if-env": "^1.1.2",
-        "@netlify/build": "^27.1.3",
+        "@netlify/build": "^27.1.2",
         "@netlify/eslint-config-node": "^5.1.8",
         "@testing-library/cypress": "^8.0.1",
         "@types/fs-extra": "^9.0.13",
@@ -3651,9 +3651,9 @@
       "dev": true
     },
     "node_modules/@netlify/build": {
-      "version": "27.1.3",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.1.3.tgz",
-      "integrity": "sha512-M/MZUqjXP+mUCbcxKEWTiN2XNiz1Xyc1+bD2/MApgbBiujFkp0fwHNYaLxNShLGLQyHYceTN2d5hz74QMUYiUA==",
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.1.2.tgz",
+      "integrity": "sha512-8G4+kjRShtYfZY/IsM0Mks6KBkTPArRNwDuj/40nlCS6I7Mb+NBcBqUXp/0tVE/Toksws1bvXBXJ9hRnoCaw8w==",
       "dev": true,
       "dependencies": {
         "@bugsnag/js": "^7.0.0",
@@ -24231,7 +24231,7 @@
       },
       "devDependencies": {
         "@delucis/if-env": "^1.1.2",
-        "@netlify/build": "^27.1.3",
+        "@netlify/build": "^27.1.2",
         "@types/fs-extra": "^9.0.13",
         "@types/jest": "^27.4.1",
         "@types/node": "^17.0.25",
@@ -26696,9 +26696,9 @@
       }
     },
     "@netlify/build": {
-      "version": "27.1.3",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.1.3.tgz",
-      "integrity": "sha512-M/MZUqjXP+mUCbcxKEWTiN2XNiz1Xyc1+bD2/MApgbBiujFkp0fwHNYaLxNShLGLQyHYceTN2d5hz74QMUYiUA==",
+      "version": "27.1.2",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-27.1.2.tgz",
+      "integrity": "sha512-8G4+kjRShtYfZY/IsM0Mks6KBkTPArRNwDuj/40nlCS6I7Mb+NBcBqUXp/0tVE/Toksws1bvXBXJ9hRnoCaw8w==",
       "dev": true,
       "requires": {
         "@bugsnag/js": "^7.0.0",
@@ -27579,7 +27579,7 @@
       "version": "file:plugin",
       "requires": {
         "@delucis/if-env": "^1.1.2",
-        "@netlify/build": "^27.1.3",
+        "@netlify/build": "^27.1.2",
         "@netlify/functions": "^1.0.0",
         "@netlify/ipx": "^1.1.0",
         "@types/fs-extra": "^9.0.13",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-typescript": "^7.16.0",
     "@delucis/if-env": "^1.1.2",
-    "@netlify/build": "^27.1.3",
+    "@netlify/build": "^27.1.2",
     "@netlify/eslint-config-node": "^5.1.8",
     "@testing-library/cypress": "^8.0.1",
     "@types/fs-extra": "^9.0.13",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@delucis/if-env": "^1.1.2",
-    "@netlify/build": "^27.1.3",
+    "@netlify/build": "^27.1.2",
     "@types/fs-extra": "^9.0.13",
     "@types/jest": "^27.4.1",
     "@types/node": "^17.0.25",


### PR DESCRIPTION
### Summary

This reverts commit 1770e7c65f156f8b5aedf2bf43b5f3898b4b7092 as it was causing issues with builds. Looking at the changes between `@netlify/build` 27.1.2 and 27.1.3, I'm still not sure why this is breaking things as the only change was validating the edge functions config, https://github.com/netlify/build/pull/4291. See https://github.com/netlify/build/releases/tag/build-v27.1.3

### Test plan

1. All the deploy previews should build now.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![A beaver enjoying the water](https://media.giphy.com/media/3og0IBnG9wJlbKL0Gc/giphy.gif)

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [x] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
