### PR TITLE
fix: handle missing manifest functions field

### DIFF
--- a/plugin/src/helpers/edge.ts
+++ b/plugin/src/helpers/edge.ts
@@ -155,14 +155,17 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
     })
     manifest.functions.push(functionDefinition)
   }
-
-  for (const edgeFunctionDefinition of Object.values(middlewareManifest.functions)) {
-    const functionDefinition = await writeEdgeFunction({
-      edgeFunctionDefinition,
-      edgeFunctionRoot,
-      netlifyConfig,
-    })
-    manifest.functions.push(functionDefinition)
+  // Older versions of the manifest format don't have the functions field
+  // No, the version field was not incremented
+  if (typeof middlewareManifest.functions === 'object') {
+    for (const edgeFunctionDefinition of Object.values(middlewareManifest.functions)) {
+      const functionDefinition = await writeEdgeFunction({
+        edgeFunctionDefinition,
+        edgeFunctionRoot,
+        netlifyConfig,
+      })
+      manifest.functions.push(functionDefinition)
+    }
   }
 
   await writeJson(join(edgeFunctionRoot, 'manifest.json'), manifest)


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Fix to problem building sites in versions of Next which don't define `functions` in middleware manifest

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
