### PR TITLE
feat: dx updates to default demo site

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Attach",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    }
+  ]
+}

--- a/demos/default/package.json
+++ b/demos/default/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "description": "",
   "scripts": {
-    "build": "next build"
+    "build": "next build",
+    "dev": "next dev",
+    "serve": "next build && next start"
   },
   "repository": {
     "type": "git",

--- a/demos/default/pages/getStaticProps/[id].js
+++ b/demos/default/pages/getStaticProps/[id].js
@@ -1,14 +1,14 @@
 import Link from 'next/link'
 
-const Show = ({ show }) => (
+const Show = ({ show, time }) => (
   <div>
     <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
-
+    <p>Ids 1 and 2 are prerendered and others should 404.</p>
     <hr />
 
     <h1>Show #{show.id}</h1>
     <p>{show.name}</p>
-
+    <p>Rendered at {time} (slowly)</p>
     <hr />
 
     <Link href="/">
@@ -32,10 +32,12 @@ export async function getStaticProps({ params }) {
 
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
+  const time = new Date().toLocaleTimeString()
 
   return {
     props: {
       show: data,
+      time,
     },
   }
 }

--- a/demos/default/pages/getStaticProps/withFallback/[...slug].js
+++ b/demos/default/pages/getStaticProps/withFallback/[...slug].js
@@ -1,11 +1,9 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 
-const Show = ({ show }) => {
+const Show = ({ show, time }) => {
   const router = useRouter()
 
-  // This is never shown on Netlify. We just need it for NextJS to be happy,
-  // because NextJS will render a fallback HTML page.
   if (router.isFallback) {
     return <div>Loading...</div>
   }
@@ -13,12 +11,16 @@ const Show = ({ show }) => {
   return (
     <div>
       <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
-
+      <p>
+        Paths /my/path/1 and /my/path/2 are prerendered and any other path should show a{' '}
+        <a href="https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-true">fallback page</a>{' '}
+        while rendering.
+      </p>
       <hr />
 
       <h1>Show #{show.id}</h1>
       <p>{show.name}</p>
-
+      <p>Rendered at {time} </p>
       <hr />
 
       <Link href="/">
@@ -44,10 +46,12 @@ export async function getStaticProps({ params }) {
 
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
+  const time = new Date().toLocaleTimeString()
 
   return {
     props: {
       show: data,
+      time,
     },
   }
 }

--- a/demos/default/pages/getStaticProps/withFallback/[id].js
+++ b/demos/default/pages/getStaticProps/withFallback/[id].js
@@ -1,11 +1,9 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 
-const Show = ({ show }) => {
+const Show = ({ show, time }) => {
   const router = useRouter()
 
-  // This is never shown on Netlify. We just need it for NextJS to be happy,
-  // because NextJS will render a fallback HTML page.
   if (router.isFallback) {
     return <div>Loading...</div>
   }
@@ -13,12 +11,16 @@ const Show = ({ show }) => {
   return (
     <div>
       <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
-
+      <p>
+        Ids 1 and 2 are prerendered and others should show a{' '}
+        <a href="https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-true">fallback page</a>{' '}
+        while rendering.
+      </p>
       <hr />
 
       <h1>Show #{show.id}</h1>
       <p>{show.name}</p>
-
+      <p>Rendered at {time} </p>
       <hr />
 
       <Link href="/">
@@ -30,7 +32,7 @@ const Show = ({ show }) => {
 
 export async function getStaticPaths() {
   // Set the paths we want to pre-render
-  const paths = [{ params: { id: '3' } }, { params: { id: '4' } }]
+  const paths = [{ params: { id: '1' } }, { params: { id: '2' } }]
 
   // We'll pre-render these paths at build time.
   // { fallback: true } means other routes will be rendered at runtime.
@@ -43,10 +45,12 @@ export async function getStaticProps({ params }) {
 
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
+  const time = new Date().toLocaleTimeString()
 
   return {
     props: {
       show: data,
+      time,
     },
   }
 }

--- a/demos/default/pages/getStaticProps/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withFallbackBlocking/[id].js
@@ -1,36 +1,26 @@
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 
-const Show = ({ show }) => {
-  const router = useRouter()
+const Show = ({ show, time }) => (
+  <div>
+    <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
+    <p>Ids 1 and 2 are prerendered and others should render on-demand.</p>
+    <hr />
 
-  // This is never shown on Netlify. We just need it for NextJS to be happy,
-  // because NextJS will render a fallback HTML page.
-  if (router.isFallback) {
-    return <div>Loading...</div>
-  }
+    <h1>Show #{show.id}</h1>
+    <p>{show.name}</p>
+    <p>Rendered at {time} </p>
+    <hr />
 
-  return (
-    <div>
-      <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
-
-      <hr />
-
-      <h1>Show #{show.id}</h1>
-      <p>{show.name}</p>
-
-      <hr />
-
-      <Link href="/">
-        <a>Go back home</a>
-      </Link>
-    </div>
-  )
-}
+    <Link href="/">
+      <a>Go back home</a>
+    </Link>
+  </div>
+)
 
 export async function getStaticPaths() {
   // Set the paths we want to pre-render
-  const paths = [{ params: { id: '3' } }, { params: { id: '4' } }]
+  const paths = [{ params: { id: '1' } }, { params: { id: '2' } }]
 
   // We'll pre-render these paths at build time.
   // { fallback: blocking } means routes will be built when visited for the
@@ -44,10 +34,12 @@ export async function getStaticProps({ params }) {
 
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
+  const time = new Date().toLocaleTimeString()
 
   return {
     props: {
       show: data,
+      time,
     },
   }
 }

--- a/demos/default/pages/getStaticProps/withRevalidate/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/[id].js
@@ -3,7 +3,8 @@ import Link from 'next/link'
 const Show = ({ show, time }) => (
   <div>
     <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
-
+    <p>Ids 1 and 2 are prerendered and others should 404.</p>
+    <p>The page should be revalidated after 60 seconds.</p>
     <hr />
 
     <h1>Show #{show.id}</h1>
@@ -33,13 +34,13 @@ export async function getStaticProps({ params }) {
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
-  await new Promise((resolve) => setTimeout(resolve, 3000))
+
   return {
     props: {
       show: data,
       time,
     },
-    revalidate: 1,
+    revalidate: 60,
   }
 }
 

--- a/demos/default/pages/getStaticProps/withRevalidate/withFallback/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallback/[id].js
@@ -1,21 +1,35 @@
+import { useRouter } from 'next/router'
 import Link from 'next/link'
 
-const Show = ({ show }) => (
-  <div>
-    <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
+const Show = ({ show, time }) => {
+  const router = useRouter()
 
-    <hr />
+  if (router.isFallback) {
+    return <div>Loading...</div>
+  }
 
-    <h1>Show #{show?.id}</h1>
-    <p>{show?.name}</p>
+  return (
+    <div>
+      <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
+      <p>
+        Ids 1 and 2 are prerendered and others should show a{' '}
+        <a href="https://nextjs.org/docs/api-reference/data-fetching/get-static-paths#fallback-true">fallback page</a>{' '}
+        while rendering.
+      </p>
+      <p>The page should be revalidated after 60 seconds.</p>
+      <hr />
 
-    <hr />
+      <h1>Show #{show.id}</h1>
+      <p>{show.name}</p>
+      <p>Rendered at {time} </p>
+      <hr />
 
-    <Link href="/">
-      <a>Go back home</a>
-    </Link>
-  </div>
-)
+      <Link href="/">
+        <a>Go back home</a>
+      </Link>
+    </div>
+  )
+}
 
 export async function getStaticPaths() {
   // Set the paths we want to pre-render
@@ -32,12 +46,14 @@ export async function getStaticProps({ params }) {
 
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
+  const time = new Date().toLocaleTimeString()
 
   return {
     props: {
       show: data,
+      time,
     },
-    revalidate: 1,
+    revalidate: 60,
   }
 }
 

--- a/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
+++ b/demos/default/pages/getStaticProps/withRevalidate/withFallbackBlocking/[id].js
@@ -3,7 +3,8 @@ import Link from 'next/link'
 const Show = ({ show, time }) => (
   <div>
     <p>This page uses getStaticProps() to pre-fetch a TV show.</p>
-    <p>Ids 1 and 2 are prerendered</p>
+    <p>Ids 1 and 2 are prerendered and others should render on-demand.</p>
+    <p>The page should be revalidated after 60 seconds.</p>
     <hr />
 
     <h1>Show #{show.id}</h1>
@@ -33,6 +34,7 @@ export async function getStaticProps({ params }) {
   const res = await fetch(`https://api.tvmaze.com/shows/${id}`)
   const data = await res.json()
   const time = new Date().toLocaleTimeString()
+
   return {
     props: {
       show: data,

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -111,58 +111,88 @@ const Index = ({ shows, nodeEnv }) => {
         <h2>Page types</h2>
         <ul>
           <li>
-            <Link href="/getServerSideProps/1">
-              <a>/getServerSideProps/1</a>
+            <Link href="/getServerSideProps/static">
+              <a>/getServerSideProps/static (SSR)</a>
             </Link>
           </li>
           <li>
-            <Link href="/getServerSideProps/static">
-              <a>/getServerSideProps/static</a>
+            <Link href="/getServerSideProps/1">
+              <a>/getServerSideProps/1 (SSR)</a>
             </Link>
           </li>
           <li>
             <Link href="/getServerSideProps/all/1">
-              <a>/getServerSideProps/all/1</a>
-            </Link>
-          </li>
-          <li>
-            <Link href="/getStaticProps/1">
-              <a>/getStaticProps/1</a>
+              <a>/getServerSideProps/all/1 (SSR)</a>
             </Link>
           </li>
           <li>
             <Link href="/getStaticProps/static">
-              <a>/getStaticProps/static</a>
+              <a>/getStaticProps/static (CDN)</a>
             </Link>
           </li>
           <li>
-            <Link href="/getStaticProps/with-revalidate">
-              <a>/getStaticProps/with-revalidate</a>
+            <Link href="/getStaticProps/1">
+              <a>/getStaticProps/1 (CDN)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/3">
+              <a>/getStaticProps/3 (404)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withFallback/1">
+              <a>/getStaticProps/withFallback/1 (CDN)</a>
             </Link>
           </li>
           <li>
             <Link href="/getStaticProps/withFallback/3">
-              <a>/getStaticProps/withFallback/3 (pre-rendered)</a>
+              <a>/getStaticProps/withFallback/3 (ODB)</a>
             </Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withFallback/300">
-              <a>/getStaticProps/withFallback/300 (SSR)</a>
+            <Link href="/getStaticProps/withFallbackBlocking/1">
+              <a>/getStaticProps/withFallbackBlocking/1 (CDN)</a>
             </Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withFallbackBlocking/300">
-              <a>/getStaticProps/withFallbackBlocking/300 (SSR)</a>
+            <Link href="/getStaticProps/withFallbackBlocking/3">
+              <a>/getStaticProps/withFallbackBlocking/3 (SSR)</a>
             </Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withRevalidate/2">
-              <a>/getStaticProps/withRevalidate/2</a>
+            <Link href="/getStaticProps/with-revalidate">
+              <a>/getStaticProps/with-revalidate (ODB)</a>
             </Link>
           </li>
           <li>
-            <Link href="/getStaticProps/withRevalidate/withFallback/200">
-              <a>/getStaticProps/withRevalidate/withFallback/200</a>
+            <Link href="/getStaticProps/withRevalidate/1">
+              <a>/getStaticProps/withRevalidate/1 (ODB)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withRevalidate/3">
+              <a>/getStaticProps/withRevalidate/3 (404)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withRevalidate/withFallback/1">
+              <a>/getStaticProps/withRevalidate/withFallback/1 (ODB)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withRevalidate/withFallback/3">
+              <a>/getStaticProps/withRevalidate/withFallback/3 (ODB)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withRevalidate/withFallbackBlocking/1">
+              <a>/getStaticProps/withRevalidate/withFallbackBlocking/1 (ODB)</a>
+            </Link>
+          </li>
+          <li>
+            <Link href="/getStaticProps/withRevalidate/withFallbackBlocking/3">
+              <a>/getStaticProps/withRevalidate/withFallbackBlocking/3 (404)</a>
             </Link>
           </li>
           <li>

--- a/demos/default/pages/index.js
+++ b/demos/default/pages/index.js
@@ -157,7 +157,7 @@ const Index = ({ shows, nodeEnv }) => {
           </li>
           <li>
             <Link href="/getStaticProps/withFallbackBlocking/3">
-              <a>/getStaticProps/withFallbackBlocking/3 (SSR)</a>
+              <a>/getStaticProps/withFallbackBlocking/3 (ODB)</a>
             </Link>
           </li>
           <li>
@@ -192,7 +192,7 @@ const Index = ({ shows, nodeEnv }) => {
           </li>
           <li>
             <Link href="/getStaticProps/withRevalidate/withFallbackBlocking/3">
-              <a>/getStaticProps/withRevalidate/withFallbackBlocking/3 (404)</a>
+              <a>/getStaticProps/withRevalidate/withFallbackBlocking/3 (ODB)</a>
             </Link>
           </li>
           <li>

--- a/plugin/src/templates/getHandler.ts
+++ b/plugin/src/templates/getHandler.ts
@@ -127,7 +127,9 @@ const makeHandler = (conf: NextConfig, app, pageRoot, staticManifest: Array<[str
       multiValueHeaders['cache-control'] = ['public, max-age=0, must-revalidate']
     }
     multiValueHeaders['x-render-mode'] = [requestMode]
-    console.log(`[${event.httpMethod}] ${event.path} (${requestMode?.toUpperCase()})`)
+    console.log(
+      `[${event.httpMethod}] ${event.path} (${requestMode?.toUpperCase()}${result.ttl > 0 ? ` ${result.ttl}s` : ''})`,
+    )
     return {
       ...result,
       multiValueHeaders,

--- a/test/__snapshots__/index.js.snap
+++ b/test/__snapshots__/index.js.snap
@@ -191,20 +191,20 @@ Array [
     "_next/data/build-id/en/getStaticProps/static.json",
   ],
   Array [
-    "en/getStaticProps/withFallback/3.html",
-    "en/getStaticProps/withFallback/3.html",
+    "en/getStaticProps/withFallback/1.html",
+    "en/getStaticProps/withFallback/1.html",
   ],
   Array [
-    "en/getStaticProps/withFallback/3.json",
-    "_next/data/build-id/en/getStaticProps/withFallback/3.json",
+    "en/getStaticProps/withFallback/1.json",
+    "_next/data/build-id/en/getStaticProps/withFallback/1.json",
   ],
   Array [
-    "en/getStaticProps/withFallback/4.html",
-    "en/getStaticProps/withFallback/4.html",
+    "en/getStaticProps/withFallback/2.html",
+    "en/getStaticProps/withFallback/2.html",
   ],
   Array [
-    "en/getStaticProps/withFallback/4.json",
-    "_next/data/build-id/en/getStaticProps/withFallback/4.json",
+    "en/getStaticProps/withFallback/2.json",
+    "_next/data/build-id/en/getStaticProps/withFallback/2.json",
   ],
   Array [
     "en/getStaticProps/withFallback/my/path/1.html",
@@ -223,20 +223,20 @@ Array [
     "_next/data/build-id/en/getStaticProps/withFallback/my/path/2.json",
   ],
   Array [
-    "en/getStaticProps/withFallbackBlocking/3.html",
-    "en/getStaticProps/withFallbackBlocking/3.html",
+    "en/getStaticProps/withFallbackBlocking/1.html",
+    "en/getStaticProps/withFallbackBlocking/1.html",
   ],
   Array [
-    "en/getStaticProps/withFallbackBlocking/3.json",
-    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/3.json",
+    "en/getStaticProps/withFallbackBlocking/1.json",
+    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/1.json",
   ],
   Array [
-    "en/getStaticProps/withFallbackBlocking/4.html",
-    "en/getStaticProps/withFallbackBlocking/4.html",
+    "en/getStaticProps/withFallbackBlocking/2.html",
+    "en/getStaticProps/withFallbackBlocking/2.html",
   ],
   Array [
-    "en/getStaticProps/withFallbackBlocking/4.json",
-    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/4.json",
+    "en/getStaticProps/withFallbackBlocking/2.json",
+    "_next/data/build-id/en/getStaticProps/withFallbackBlocking/2.json",
   ],
   Array [
     "en/image.html",


### PR DESCRIPTION
### Summary

While testing the various rendering modes I made a few changes to the demo pages so that they were easier to test and it was more obvious how each page should be rendered. I thought it might be good to push these changes, if everyone agrees they are useful?

* Added descriptive text at the top of each page with a dynamic path that explains which paths are prerendered and what fallback options are enabled for other slugs
* Made the prerendered paths more consistent (always IDs 1 and 2)
* Added some package scripts for testing with `next build && next start`
* Added a simple VS Code launch.json for attaching the debugging to running inspector process

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

<img src="https://pbs.twimg.com/media/FV0r4iAWQAAvwAF?format=jpg&name=medium" alt="chill cat" width="600">