### PR TITLE
fix: explicitly type image config in ipx edge function

### DIFF
--- a/plugin/src/templates/edge/ipx.ts
+++ b/plugin/src/templates/edge/ipx.ts
@@ -1,10 +1,15 @@
 import { Accepts } from "https://deno.land/x/accepts@2.1.1/mod.ts";
 import type { Context } from "netlify:edge";
+// Available at build time
 import imageconfig from "../functions-internal/_ipx/imageconfig.json" assert {
   type: "json",
 };
 
 const defaultFormat = "webp"
+
+interface ImageConfig extends Record<string, unknown> {
+  formats?: string[];
+}
 
 /**
  * Implement content negotiation for images
@@ -14,7 +19,7 @@ const defaultFormat = "webp"
 const handler = async (req: Request, context: Context) => {
   const { searchParams } = new URL(req.url);
   const accept = new Accepts(req.headers);
-  const { formats = [defaultFormat] } = imageconfig;
+  const { formats = [defaultFormat] } = imageconfig as ImageConfig;
   if (formats.length === 0) {
     formats.push(defaultFormat);
   }


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Explicitly type the imageconfig.json in the ipx content negotiation edge function. This fixes a bundling error in the case where the Next config is missing the formats key, meaning the inferred type was invalid.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal

![baby capybara](https://user-images.githubusercontent.com/213306/178447020-fb69b11d-cf59-4b89-94e7-28454714c8af.png)
