### PR TITLE
feat: get client IP from Context object rather than header

### DIFF
--- a/plugin/src/templates/edge/runtime.ts
+++ b/plugin/src/templates/edge/runtime.ts
@@ -47,7 +47,7 @@ const handler = async (req: Request, context: Context) => {
     },
     url: url.toString(),
     method: req.method,
-    ip: req.headers.get('x-nf-client-address') ?? undefined,
+    ip: context.ip,
     body: req.body ?? undefined,
   }
 


### PR DESCRIPTION
### Summary

Gets the client IP address from the Context object rather than the header.

