### PR TITLE
fix: copy imageconfig into edge function dir

### DIFF
--- a/plugin/src/helpers/edge.ts
+++ b/plugin/src/helpers/edge.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */ 
+/* eslint-disable max-lines */
 import { promises as fs, existsSync } from 'fs'
 import { resolve, join } from 'path'
 
@@ -190,4 +190,4 @@ export const updateConfig = async (publish: string) => {
   config.config.env.NEXT_USE_NETLIFY_EDGE = 'true'
   await writeJSON(configFile, config)
 }
-/* eslint-enable max-lines */ 
+/* eslint-enable max-lines */

--- a/plugin/src/helpers/edge.ts
+++ b/plugin/src/helpers/edge.ts
@@ -1,8 +1,9 @@
+/* eslint-disable max-lines */ 
 import { promises as fs, existsSync } from 'fs'
 import { resolve, join } from 'path'
 
 import type { NetlifyConfig } from '@netlify/build'
-import { emptyDir, ensureDir, readJSON, readJson, writeJSON, writeJson } from 'fs-extra'
+import { copyFile, emptyDir, ensureDir, readJSON, readJson, writeJSON, writeJson } from 'fs-extra'
 import type { MiddlewareManifest } from 'next/dist/build/webpack/plugins/middleware-plugin'
 
 type EdgeFunctionDefinition = MiddlewareManifest['middleware']['name']
@@ -139,7 +140,13 @@ export const writeEdgeFunctions = async (netlifyConfig: NetlifyConfig) => {
         'Using Netlify Edge Functions for image format detection. Set env var "NEXT_DISABLE_EDGE_IMAGES=true" to disable.',
       )
     }
-    await copyEdgeSourceFile({ edgeFunctionDir: edgeFunctionRoot, file: 'ipx.ts' })
+    const edgeFunctionDir = join(edgeFunctionRoot, 'ipx')
+    await ensureDir(edgeFunctionDir)
+    await copyEdgeSourceFile({ edgeFunctionDir, file: 'ipx.ts', target: 'index.ts' })
+    await copyFile(
+      join('.netlify', 'functions-internal', '_ipx', 'imageconfig.json'),
+      join(edgeFunctionDir, 'imageconfig.json'),
+    )
     manifest.functions.push({
       function: 'ipx',
       path: '/_next/image*',
@@ -183,3 +190,4 @@ export const updateConfig = async (publish: string) => {
   config.config.env.NEXT_USE_NETLIFY_EDGE = 'true'
   await writeJSON(configFile, config)
 }
+/* eslint-enable max-lines */ 

--- a/plugin/src/templates/edge/ipx.ts
+++ b/plugin/src/templates/edge/ipx.ts
@@ -1,7 +1,7 @@
 import { Accepts } from "https://deno.land/x/accepts@2.1.1/mod.ts";
 import type { Context } from "netlify:edge";
 // Available at build time
-import imageconfig from "../functions-internal/_ipx/imageconfig.json" assert {
+import imageconfig from "./imageconfig.json" assert {
   type: "json",
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -40,7 +40,7 @@ const chance = new Chance()
 const FIXTURES_DIR = `${__dirname}/fixtures`
 const SAMPLE_PROJECT_DIR = `${__dirname}/../demos/default`
 const constants = {
-  INTERNAL_FUNCTIONS_SRC: '.netlify/internal-functions',
+  INTERNAL_FUNCTIONS_SRC: '.netlify/functions-internal',
   PUBLISH_DIR: '.next',
   FUNCTIONS_DIST: '.netlify/functions',
 }
@@ -368,12 +368,12 @@ describe('onBuild()', () => {
 
     await plugin.onBuild(defaultArgs)
 
-    expect(existsSync(`.netlify/internal-functions/___netlify-handler/___netlify-handler.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/internal-functions/___netlify-handler/bridge.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/internal-functions/___netlify-handler/handlerUtils.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/internal-functions/___netlify-odb-handler/___netlify-odb-handler.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/internal-functions/___netlify-odb-handler/bridge.js`)).toBeTruthy()
-    expect(existsSync(`.netlify/internal-functions/___netlify-odb-handler/handlerUtils.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-handler/___netlify-handler.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-handler/bridge.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-handler/handlerUtils.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/___netlify-odb-handler.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/bridge.js`)).toBeTruthy()
+    expect(existsSync(`.netlify/functions-internal/___netlify-odb-handler/handlerUtils.js`)).toBeTruthy()
   })
 
   test('writes correct redirects to netlifyConfig', async () => {


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

Currently the ipx edge function imports the `imageconfig.json` from `functions-internal/_ipx`. However this was causing problems when using ESZIP for bundling. This PR changes it to copy the JSON file into the  edge functions dir and imports it as a sibling file. This works as expected.

### Test plan

In the `demos/default` directory, run `node ../../node_modules/@netlify/build/src/core/bin.js --featureFlags=edge_functions_produce_eszip`

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
![two capy friends](https://pbs.twimg.com/media/FTXrmmlXoAADW2i?format=jpg&name=small)
### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
