### PR TITLE
fix: replace netlify:edge identifier with full URL

### DIFF
--- a/plugin/src/templates/edge/ipx.ts
+++ b/plugin/src/templates/edge/ipx.ts
@@ -1,5 +1,5 @@
 import { Accepts } from 'https://deno.land/x/accepts@2.1.1/mod.ts'
-import type { Context } from 'netlify:edge'
+import type { Context } from 'https://edge.netlify.com'
 // Available at build time
 import imageconfig from './imageconfig.json' assert { type: 'json' }
 

--- a/plugin/src/templates/edge/runtime.ts
+++ b/plugin/src/templates/edge/runtime.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'netlify:edge'
+import type { Context } from 'https://edge.netlify.com'
 
 import edgeFunction from './bundle.js'
 import { buildResponse } from './utils.ts'

--- a/plugin/src/templates/edge/utils.ts
+++ b/plugin/src/templates/edge/utils.ts
@@ -1,4 +1,4 @@
-import type { Context } from 'netlify:edge'
+import type { Context } from 'https://edge.netlify.com'
 import { ElementHandlers, HTMLRewriter } from 'https://deno.land/x/html_rewriter@v0.1.0-pre.17/index.ts'
 
 export interface FetchEventResult {


### PR DESCRIPTION
### Summary

This replaces `netlify:edge` with `https://edge.netlify.com`.

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal
Part of https://github.com/netlify/pillar-runtime/issues/322.

![cute pug playing a guitar](https://media.giphy.com/media/ZubZqIeSsZ60t0ID9l/giphy-downsized.gif)

### Standard checks:

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
