### PR TITLE
fix: allow proxy of /_next/static

### DIFF
--- a/plugin/src/templates/edge/runtime.ts
+++ b/plugin/src/templates/edge/runtime.ts
@@ -46,9 +46,6 @@ globalThis.NFRequestContextMap ||= new Map()
 
 const handler = async (req: Request, context: Context) => {
   const url = new URL(req.url)
-  if (url.pathname.startsWith('/_next/static/')) {
-    return
-  }
 
   const geo = {
     country: context.geo.country?.code,


### PR DESCRIPTION
<!--Please tag yourself as the Assignee and netlify/frameworks as the Reviewer -->

### Summary

The next plugin doesn't proxy /_next/static/ when request as it gets dropped. This stops chunks from loading when proxied to a different Next.js site.

### Test plan

1. Visit the Deploy Preview ([insert link to specific page]()) ...

### Relevant links (GitHub issues, Notion docs, etc.) or a picture of cute animal


### Standard checks:

<!-- Please delete any options that reviewers shouldn't check. -->

- [ ] Check the Deploy Preview's Demo site for your PR's functionality
- [ ] Add docs when necessary

---

🧪 Once merged, make sure to update the version if needed and that it was published correctly.
